### PR TITLE
Upgrading to Fennel 1.4.0

### DIFF
--- a/static/fennel/LICENSE
+++ b/static/fennel/LICENSE
@@ -1,7 +1,5 @@
 MIT License
 
-Copyright © 2016-2022 Calvin Rose and contributors
-
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/static/fennel/fennel.lua
+++ b/static/fennel/fennel.lua
@@ -1,3 +1,5 @@
+-- SPDX-License-Identifier: MIT
+-- SPDX-FileCopyrightText: Calvin Rose and contributors
 package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
   local utils = require("fennel.utils")
   local parser = require("fennel.parser")
@@ -5,15 +7,16 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
   local specials = require("fennel.specials")
   local view = require("fennel.view")
   local unpack = (table.unpack or _G.unpack)
-  local function default_read_chunk(parser_state)
-    local function _604_()
-      if (0 < parser_state["stack-size"]) then
-        return ".."
-      else
-        return ">> "
-      end
+  local depth = 0
+  local function prompt_for(top_3f)
+    if top_3f then
+      return (string.rep(">", (depth + 1)) .. " ")
+    else
+      return (string.rep(".", (depth + 1)) .. " ")
     end
-    io.write(_604_())
+  end
+  local function default_read_chunk(parser_state)
+    io.write(prompt_for((0 == parser_state["stack-size"])))
     io.flush()
     local input = io.read()
     return (input and (input .. "\n"))
@@ -23,18 +26,18 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     return io.write("\n")
   end
   local function default_on_error(errtype, err, lua_source)
-    local function _606_()
-      local _605_0 = errtype
-      if (_605_0 == "Lua Compile") then
+    local function _612_()
+      local _611_0 = errtype
+      if (_611_0 == "Lua Compile") then
         return ("Bad code generated - likely a bug with the compiler:\n" .. "--- Generated Lua Start ---\n" .. lua_source .. "--- Generated Lua End ---\n")
-      elseif (_605_0 == "Runtime") then
+      elseif (_611_0 == "Runtime") then
         return (compiler.traceback(tostring(err), 4) .. "\n")
       else
-        local _ = _605_0
+        local _ = _611_0
         return ("%s error: %s\n"):format(errtype, tostring(err))
       end
     end
-    return io.write(_606_())
+    return io.write(_612_())
   end
   local function splice_save_locals(env, lua_source, scope)
     local saves = nil
@@ -42,7 +45,7 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
       local tbl_17_ = {}
       local i_18_ = #tbl_17_
       for name in pairs(env.___replLocals___) do
-        local val_19_ = ("local %s = ___replLocals___['%s']"):format((scope.manglings[name] or name), name)
+        local val_19_ = ("local %s = ___replLocals___[%q]"):format((scope.manglings[name] or name), name)
         if (nil ~= val_19_) then
           i_18_ = (i_18_ + 1)
           tbl_17_[i_18_] = val_19_
@@ -57,7 +60,7 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
       for raw, name in pairs(scope.manglings) do
         local val_19_ = nil
         if not scope.gensyms[name] then
-          val_19_ = ("___replLocals___['%s'] = %s"):format(raw, name)
+          val_19_ = ("___replLocals___[%q] = %s"):format(raw, name)
         else
         val_19_ = nil
         end
@@ -74,25 +77,25 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     else
       gap = " "
     end
-    local function _612_()
+    local function _618_()
       if next(saves) then
         return (table.concat(saves, " ") .. gap)
       else
         return ""
       end
     end
-    local function _615_()
-      local _613_0, _614_0 = lua_source:match("^(.*)[\n ](return .*)$")
-      if ((nil ~= _613_0) and (nil ~= _614_0)) then
-        local body = _613_0
-        local _return = _614_0
+    local function _621_()
+      local _619_0, _620_0 = lua_source:match("^(.*)[\n ](return .*)$")
+      if ((nil ~= _619_0) and (nil ~= _620_0)) then
+        local body = _619_0
+        local _return = _620_0
         return (body .. gap .. table.concat(binds, " ") .. gap .. _return)
       else
-        local _ = _613_0
+        local _ = _619_0
         return lua_source
       end
     end
-    return (_612_() .. _615_())
+    return (_618_() .. _621_())
   end
   local function completer(env, scope, text)
     local max_items = 2000
@@ -104,14 +107,14 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
       local scope_first_3f = ((tbl == env) or (tbl == env.___replLocals___))
       local tbl_17_ = matches
       local i_18_ = #tbl_17_
-      local function _617_()
+      local function _623_()
         if scope_first_3f then
           return scope.manglings
         else
           return tbl
         end
       end
-      for k, is_mangled in utils.allpairs(_617_()) do
+      for k, is_mangled in utils.allpairs(_623_()) do
         if (max_items <= #matches) then break end
         local val_19_ = nil
         do
@@ -179,7 +182,7 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     return input:match("^%s*,")
   end
   local function command_docs()
-    local _626_
+    local _632_
     do
       local tbl_17_ = {}
       local i_18_ = #tbl_17_
@@ -190,18 +193,18 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
           tbl_17_[i_18_] = val_19_
         end
       end
-      _626_ = tbl_17_
+      _632_ = tbl_17_
     end
-    return table.concat(_626_, "\n")
+    return table.concat(_632_, "\n")
   end
   commands.help = function(_, _0, on_values)
-    return on_values({("Welcome to Fennel.\nThis is the REPL where you can enter code to be evaluated.\nYou can also run these repl commands:\n\n" .. command_docs() .. "\n  ,exit - Leave the repl.\n\nUse ,doc something to see descriptions for individual macros and special forms.\n\nFor more information about the language, see https://fennel-lang.org/reference")})
+    return on_values({("Welcome to Fennel.\nThis is the REPL where you can enter code to be evaluated.\nYou can also run these repl commands:\n\n" .. command_docs() .. "\n  ,return FORM - Evaluate FORM and return its value to the REPL's caller.\n  ,exit - Leave the repl.\n\nUse ,doc something to see descriptions for individual macros and special forms.\nValues from previous inputs are kept in *1, *2, and *3.\n\nFor more information about the language, see https://fennel-lang.org/reference")})
   end
   do end (compiler.metadata):set(commands.help, "fnl/docstring", "Show this message.")
   local function reload(module_name, env, on_values, on_error)
-    local _628_0, _629_0 = pcall(specials["load-code"]("return require(...)", env), module_name)
-    if ((_628_0 == true) and (nil ~= _629_0)) then
-      local old = _629_0
+    local _634_0, _635_0 = pcall(specials["load-code"]("return require(...)", env), module_name)
+    if ((_634_0 == true) and (nil ~= _635_0)) then
+      local old = _635_0
       local _ = nil
       package.loaded[module_name] = nil
       _ = nil
@@ -226,8 +229,8 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
         package.loaded[module_name] = old
       end
       return on_values({"ok"})
-    elseif ((_628_0 == false) and (nil ~= _629_0)) then
-      local msg = _629_0
+    elseif ((_634_0 == false) and (nil ~= _635_0)) then
+      local msg = _635_0
       if msg:match("loop or previous error loading module") then
         package.loaded[module_name] = nil
         return reload(module_name, env, on_values, on_error)
@@ -235,32 +238,32 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
         specials["macro-loaded"][module_name] = nil
         return nil
       else
-        local function _634_()
-          local _633_0 = msg:gsub("\n.*", "")
-          return _633_0
+        local function _640_()
+          local _639_0 = msg:gsub("\n.*", "")
+          return _639_0
         end
-        return on_error("Runtime", _634_())
+        return on_error("Runtime", _640_())
       end
     end
   end
   local function run_command(read, on_error, f)
-    local _637_0, _638_0, _639_0 = pcall(read)
-    if ((_637_0 == true) and (_638_0 == true) and (nil ~= _639_0)) then
-      local val = _639_0
-      local _640_0, _641_0 = pcall(f, val)
-      if ((_640_0 == false) and (nil ~= _641_0)) then
-        local msg = _641_0
+    local _643_0, _644_0, _645_0 = pcall(read)
+    if ((_643_0 == true) and (_644_0 == true) and (nil ~= _645_0)) then
+      local val = _645_0
+      local _646_0, _647_0 = pcall(f, val)
+      if ((_646_0 == false) and (nil ~= _647_0)) then
+        local msg = _647_0
         return on_error("Runtime", msg)
       end
-    elseif (_637_0 == false) then
+    elseif (_643_0 == false) then
       return on_error("Parse", "Couldn't parse input.")
     end
   end
   commands.reload = function(env, read, on_values, on_error)
-    local function _644_(_241)
+    local function _650_(_241)
       return reload(tostring(_241), env, on_values, on_error)
     end
-    return run_command(read, on_error, _644_)
+    return run_command(read, on_error, _650_)
   end
   do end (compiler.metadata):set(commands.reload, "fnl/docstring", "Reload the specified module.")
   commands.reset = function(env, _, on_values)
@@ -269,28 +272,28 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
   end
   do end (compiler.metadata):set(commands.reset, "fnl/docstring", "Erase all repl-local scope.")
   commands.complete = function(env, read, on_values, on_error, scope, chars)
-    local function _645_()
+    local function _651_()
       return on_values(completer(env, scope, table.concat(chars):gsub(",complete +", ""):sub(1, -2)))
     end
-    return run_command(read, on_error, _645_)
+    return run_command(read, on_error, _651_)
   end
   do end (compiler.metadata):set(commands.complete, "fnl/docstring", "Print all possible completions for a given input symbol.")
   local function apropos_2a(pattern, tbl, prefix, seen, names)
     for name, subtbl in pairs(tbl) do
       if (("string" == type(name)) and (package ~= subtbl)) then
-        local _646_0 = type(subtbl)
-        if (_646_0 == "function") then
+        local _652_0 = type(subtbl)
+        if (_652_0 == "function") then
           if ((prefix .. name)):match(pattern) then
             table.insert(names, (prefix .. name))
           end
-        elseif (_646_0 == "table") then
+        elseif (_652_0 == "table") then
           if not seen[subtbl] then
-            local _648_
+            local _654_
             do
               seen[subtbl] = true
-              _648_ = seen
+              _654_ = seen
             end
-            apropos_2a(pattern, subtbl, (prefix .. name:gsub("%.", "/") .. "."), _648_, names)
+            apropos_2a(pattern, subtbl, (prefix .. name:gsub("%.", "/") .. "."), _654_, names)
           end
         end
       end
@@ -311,10 +314,10 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     return tbl_17_
   end
   commands.apropos = function(_env, read, on_values, on_error, _scope)
-    local function _653_(_241)
+    local function _659_(_241)
       return on_values(apropos(tostring(_241)))
     end
-    return run_command(read, on_error, _653_)
+    return run_command(read, on_error, _659_)
   end
   do end (compiler.metadata):set(commands.apropos, "fnl/docstring", "Print all functions matching a pattern in all loaded modules.")
   local function apropos_follow_path(path)
@@ -334,12 +337,12 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     local tgt = package.loaded
     for _, path0 in ipairs(paths) do
       if (nil == tgt) then break end
-      local _656_
+      local _662_
       do
-        local _655_0 = path0:gsub("%/", ".")
-        _656_ = _655_0
+        local _661_0 = path0:gsub("%/", ".")
+        _662_ = _661_0
       end
-      tgt = tgt[_656_]
+      tgt = tgt[_662_]
     end
     return tgt
   end
@@ -351,9 +354,9 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
       do
         local tgt = apropos_follow_path(path)
         if ("function" == type(tgt)) then
-          local _657_0 = (compiler.metadata):get(tgt, "fnl/docstring")
-          if (nil ~= _657_0) then
-            local docstr = _657_0
+          local _663_0 = (compiler.metadata):get(tgt, "fnl/docstring")
+          if (nil ~= _663_0) then
+            local docstr = _663_0
             val_19_ = (docstr:match(pattern) and path)
           else
           val_19_ = nil
@@ -370,125 +373,125 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     return tbl_17_
   end
   commands["apropos-doc"] = function(_env, read, on_values, on_error, _scope)
-    local function _661_(_241)
+    local function _667_(_241)
       return on_values(apropos_doc(tostring(_241)))
     end
-    return run_command(read, on_error, _661_)
+    return run_command(read, on_error, _667_)
   end
   do end (compiler.metadata):set(commands["apropos-doc"], "fnl/docstring", "Print all functions that match the pattern in their docs")
   local function apropos_show_docs(on_values, pattern)
     for _, path in ipairs(apropos(pattern)) do
       local tgt = apropos_follow_path(path)
       if (("function" == type(tgt)) and (compiler.metadata):get(tgt, "fnl/docstring")) then
-        on_values(specials.doc(tgt, path))
-        on_values()
+        on_values({specials.doc(tgt, path)})
+        on_values({})
       end
     end
     return nil
   end
   commands["apropos-show-docs"] = function(_env, read, on_values, on_error)
-    local function _663_(_241)
+    local function _669_(_241)
       return apropos_show_docs(on_values, tostring(_241))
     end
-    return run_command(read, on_error, _663_)
+    return run_command(read, on_error, _669_)
   end
   do end (compiler.metadata):set(commands["apropos-show-docs"], "fnl/docstring", "Print all documentations matching a pattern in function name")
-  local function resolve(identifier, _664_0, scope)
-    local _665_ = _664_0
-    local env = _665_
-    local ___replLocals___ = _665_["___replLocals___"]
+  local function resolve(identifier, _670_0, scope)
+    local _671_ = _670_0
+    local env = _671_
+    local ___replLocals___ = _671_["___replLocals___"]
     local e = nil
-    local function _666_(_241, _242)
+    local function _672_(_241, _242)
       return (___replLocals___[scope.unmanglings[_242]] or env[_242])
     end
-    e = setmetatable({}, {__index = _666_})
-    local function _667_(...)
-      local _668_0, _669_0 = ...
-      if ((_668_0 == true) and (nil ~= _669_0)) then
-        local code = _669_0
-        local function _670_(...)
-          local _671_0, _672_0 = ...
-          if ((_671_0 == true) and (nil ~= _672_0)) then
-            local val = _672_0
+    e = setmetatable({}, {__index = _672_})
+    local function _673_(...)
+      local _674_0, _675_0 = ...
+      if ((_674_0 == true) and (nil ~= _675_0)) then
+        local code = _675_0
+        local function _676_(...)
+          local _677_0, _678_0 = ...
+          if ((_677_0 == true) and (nil ~= _678_0)) then
+            local val = _678_0
             return val
           else
-            local _ = _671_0
+            local _ = _677_0
             return nil
           end
         end
-        return _670_(pcall(specials["load-code"](code, e)))
+        return _676_(pcall(specials["load-code"](code, e)))
       else
-        local _ = _668_0
+        local _ = _674_0
         return nil
       end
     end
-    return _667_(pcall(compiler["compile-string"], tostring(identifier), {scope = scope}))
+    return _673_(pcall(compiler["compile-string"], tostring(identifier), {scope = scope}))
   end
   commands.find = function(env, read, on_values, on_error, scope)
-    local function _675_(_241)
-      local _676_0 = nil
+    local function _681_(_241)
+      local _682_0 = nil
       do
-        local _677_0 = utils["sym?"](_241)
-        if (nil ~= _677_0) then
-          local _678_0 = resolve(_677_0, env, scope)
-          if (nil ~= _678_0) then
-            _676_0 = debug.getinfo(_678_0)
+        local _683_0 = utils["sym?"](_241)
+        if (nil ~= _683_0) then
+          local _684_0 = resolve(_683_0, env, scope)
+          if (nil ~= _684_0) then
+            _682_0 = debug.getinfo(_684_0)
           else
-            _676_0 = _678_0
+            _682_0 = _684_0
           end
         else
-          _676_0 = _677_0
+          _682_0 = _683_0
         end
       end
-      if ((_G.type(_676_0) == "table") and (nil ~= _676_0.linedefined) and (nil ~= _676_0.short_src) and (nil ~= _676_0.source) and (_676_0.what == "Lua")) then
-        local line = _676_0.linedefined
-        local src = _676_0.short_src
-        local source = _676_0.source
+      if ((_G.type(_682_0) == "table") and (nil ~= _682_0.linedefined) and (nil ~= _682_0.short_src) and (nil ~= _682_0.source) and (_682_0.what == "Lua")) then
+        local line = _682_0.linedefined
+        local src = _682_0.short_src
+        local source = _682_0.source
         local fnlsrc = nil
         do
-          local _681_0 = compiler.sourcemap
-          if (nil ~= _681_0) then
-            _681_0 = _681_0[source]
+          local _687_0 = compiler.sourcemap
+          if (nil ~= _687_0) then
+            _687_0 = _687_0[source]
           end
-          if (nil ~= _681_0) then
-            _681_0 = _681_0[line]
+          if (nil ~= _687_0) then
+            _687_0 = _687_0[line]
           end
-          if (nil ~= _681_0) then
-            _681_0 = _681_0[2]
+          if (nil ~= _687_0) then
+            _687_0 = _687_0[2]
           end
-          fnlsrc = _681_0
+          fnlsrc = _687_0
         end
         return on_values({string.format("%s:%s", src, (fnlsrc or line))})
-      elseif (_676_0 == nil) then
+      elseif (_682_0 == nil) then
         return on_error("Repl", "Unknown value")
       else
-        local _ = _676_0
+        local _ = _682_0
         return on_error("Repl", "No source info")
       end
     end
-    return run_command(read, on_error, _675_)
+    return run_command(read, on_error, _681_)
   end
   do end (compiler.metadata):set(commands.find, "fnl/docstring", "Print the filename and line number for a given function")
   commands.doc = function(env, read, on_values, on_error, scope)
-    local function _686_(_241)
+    local function _692_(_241)
       local name = tostring(_241)
       local path = (utils["multi-sym?"](name) or {name})
       local ok_3f, target = nil, nil
-      local function _687_()
+      local function _693_()
         return (utils["get-in"](scope.specials, path) or utils["get-in"](scope.macros, path) or resolve(name, env, scope))
       end
-      ok_3f, target = pcall(_687_)
+      ok_3f, target = pcall(_693_)
       if ok_3f then
         return on_values({specials.doc(target, name)})
       else
         return on_error("Repl", ("Could not find " .. name .. " for docs."))
       end
     end
-    return run_command(read, on_error, _686_)
+    return run_command(read, on_error, _692_)
   end
   do end (compiler.metadata):set(commands.doc, "fnl/docstring", "Print the docstring and arglist for a function, macro, or special form.")
   commands.compile = function(env, read, on_values, on_error, scope)
-    local function _689_(_241)
+    local function _695_(_241)
       local allowedGlobals = specials["current-global-names"](env)
       local ok_3f, result = pcall(compiler.compile, _241, {allowedGlobals = allowedGlobals, env = env, scope = scope})
       if ok_3f then
@@ -497,16 +500,16 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
         return on_error("Repl", ("Error compiling expression: " .. result))
       end
     end
-    return run_command(read, on_error, _689_)
+    return run_command(read, on_error, _695_)
   end
   do end (compiler.metadata):set(commands.compile, "fnl/docstring", "compiles the expression into lua and prints the result.")
   local function load_plugin_commands(plugins)
-    for _, plugin in ipairs((plugins or {})) do
-      for name, f in pairs(plugin) do
-        local _691_0 = name:match("^repl%-command%-(.*)")
-        if (nil ~= _691_0) then
-          local cmd_name = _691_0
-          commands[cmd_name] = (commands[cmd_name] or f)
+    for i = #(plugins or {}), 1, -1 do
+      for name, f in pairs(plugins[i]) do
+        local _697_0 = name:match("^repl%-command%-(.*)")
+        if (nil ~= _697_0) then
+          local cmd_name = _697_0
+          commands[cmd_name] = f
         end
       end
     end
@@ -515,19 +518,19 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
   local function run_command_loop(input, read, loop, env, on_values, on_error, scope, chars)
     local command_name = input:match(",([^%s/]+)")
     do
-      local _693_0 = commands[command_name]
-      if (nil ~= _693_0) then
-        local command = _693_0
+      local _699_0 = commands[command_name]
+      if (nil ~= _699_0) then
+        local command = _699_0
         command(env, read, on_values, on_error, scope, chars)
       else
-        local _ = _693_0
-        if ("exit" ~= command_name) then
+        local _ = _699_0
+        if ((command_name ~= "exit") and (command_name ~= "return")) then
           on_values({"Unknown command", command_name})
         end
       end
     end
     if ("exit" ~= command_name) then
-      return loop()
+      return loop((command_name == "return"))
     end
   end
   local function try_readline_21(opts, ok, readline)
@@ -570,9 +573,9 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
   end
   local function repl(_3foptions)
     local old_root_options = utils.root.options
-    local _702_ = utils.copy(_3foptions)
-    local opts = _702_
-    local _3ffennelrc = _702_["fennelrc"]
+    local _708_ = utils.copy(_3foptions)
+    local opts = _708_
+    local _3ffennelrc = _708_["fennelrc"]
     local _ = nil
     opts.fennelrc = nil
     _ = nil
@@ -587,35 +590,42 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
     local callbacks = {env = env, onError = (opts.onError or default_on_error), onValues = (opts.onValues or default_on_values), pp = (opts.pp or view), readChunk = (opts.readChunk or default_read_chunk)}
     local save_locals_3f = (opts.saveLocals ~= false)
     local byte_stream, clear_stream = nil, nil
-    local function _704_(_241)
+    local function _710_(_241)
       return callbacks.readChunk(_241)
     end
-    byte_stream, clear_stream = parser.granulate(_704_)
+    byte_stream, clear_stream = parser.granulate(_710_)
     local chars = {}
     local read, reset = nil, nil
-    local function _705_(parser_state)
+    local function _711_(parser_state)
       local b = byte_stream(parser_state)
       if b then
         table.insert(chars, string.char(b))
       end
       return b
     end
-    read, reset = parser.parser(_705_)
+    read, reset = parser.parser(_711_)
+    depth = (depth + 1)
+    if opts.message then
+      callbacks.onValues({opts.message})
+    end
     env.___repl___ = callbacks
     opts.env, opts.scope = env, compiler["make-scope"]()
     opts.useMetadata = (opts.useMetadata ~= false)
     if (opts.allowedGlobals == nil) then
       opts.allowedGlobals = specials["current-global-names"](env)
     end
+    if opts.init then
+      opts.init(opts, depth)
+    end
     if opts.registerCompleter then
-      local function _709_()
-        local _708_0 = opts.scope
-        local function _710_(...)
-          return completer(env, _708_0, ...)
+      local function _717_()
+        local _716_0 = opts.scope
+        local function _718_(...)
+          return completer(env, _716_0, ...)
         end
-        return _710_
+        return _718_
       end
-      opts.registerCompleter(_709_())
+      opts.registerCompleter(_717_())
     end
     load_plugin_commands(opts.plugins)
     if save_locals_3f then
@@ -636,12 +646,21 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
       end
       return callbacks.onValues(out)
     end
-    local function loop()
+    local function save_value(...)
+      env.___replLocals___["*3"] = env.___replLocals___["*2"]
+      env.___replLocals___["*2"] = env.___replLocals___["*1"]
+      env.___replLocals___["*1"] = ...
+      return ...
+    end
+    opts.scope.manglings["*1"], opts.scope.unmanglings._1 = "_1", "*1"
+    opts.scope.manglings["*2"], opts.scope.unmanglings._2 = "_2", "*2"
+    opts.scope.manglings["*3"], opts.scope.unmanglings._3 = "_3", "*3"
+    local function loop(exit_next_3f)
       for k in pairs(chars) do
         chars[k] = nil
       end
       reset()
-      local ok, parser_not_eof_3f, x = pcall(read)
+      local ok, parser_not_eof_3f, form = pcall(read)
       local src_string = table.concat(chars)
       local readline_not_eof_3f = (not readline or (src_string ~= "(null)"))
       local not_eof_3f = (readline_not_eof_3f and parser_not_eof_3f)
@@ -653,52 +672,66 @@ package.preload["fennel.repl"] = package.preload["fennel.repl"] or function(...)
         return run_command_loop(src_string, read, loop, env, callbacks.onValues, callbacks.onError, opts.scope, chars)
       else
         if not_eof_3f then
-          do
-            local _714_0, _715_0 = nil, nil
-            local function _716_()
-              opts["source"] = src_string
-              return opts
-            end
-            _714_0, _715_0 = pcall(compiler.compile, x, _716_())
-            if ((_714_0 == false) and (nil ~= _715_0)) then
-              local msg = _715_0
+          local function _722_(...)
+            local _723_0, _724_0 = ...
+            if ((_723_0 == true) and (nil ~= _724_0)) then
+              local src = _724_0
+              local function _725_(...)
+                local _726_0, _727_0 = ...
+                if ((_726_0 == true) and (nil ~= _727_0)) then
+                  local chunk = _727_0
+                  local function _728_()
+                    return print_values(save_value(chunk()))
+                  end
+                  local function _729_(...)
+                    return callbacks.onError("Runtime", ...)
+                  end
+                  return xpcall(_728_, _729_)
+                elseif ((_726_0 == false) and (nil ~= _727_0)) then
+                  local msg = _727_0
+                  clear_stream()
+                  return callbacks.onError("Compile", msg)
+                end
+              end
+              local function _732_(...)
+                local src0 = nil
+                if save_locals_3f then
+                  src0 = splice_save_locals(env, src, opts.scope)
+                else
+                  src0 = src
+                end
+                return pcall(specials["load-code"], src0, env)
+              end
+              return _725_(_732_(...))
+            elseif ((_723_0 == false) and (nil ~= _724_0)) then
+              local msg = _724_0
               clear_stream()
-              callbacks.onError("Compile", msg)
-            elseif ((_714_0 == true) and (nil ~= _715_0)) then
-              local src = _715_0
-              local src0 = nil
-              if save_locals_3f then
-                src0 = splice_save_locals(env, src, opts.scope)
-              else
-                src0 = src
-              end
-              local _718_0, _719_0 = pcall(specials["load-code"], src0, env)
-              if ((_718_0 == false) and (nil ~= _719_0)) then
-                local msg = _719_0
-                clear_stream()
-                callbacks.onError("Lua Compile", msg, src0)
-              elseif (true and (nil ~= _719_0)) then
-                local _1 = _718_0
-                local chunk = _719_0
-                local function _720_()
-                  return print_values(chunk())
-                end
-                local function _721_(...)
-                  return callbacks.onError("Runtime", ...)
-                end
-                xpcall(_720_, _721_)
-              end
+              return callbacks.onError("Compile", msg)
             end
           end
+          local function _734_()
+            opts["source"] = src_string
+            return opts
+          end
+          _722_(pcall(compiler.compile, form, _734_()))
           utils.root.options = old_root_options
-          return loop()
+          if exit_next_3f then
+            return env.___replLocals___["*1"]
+          else
+            return loop()
+          end
         end
       end
     end
-    loop()
+    local value = loop()
+    depth = (depth - 1)
     if readline then
-      return readline.save_history()
+      readline.save_history()
     end
+    if opts.exit then
+      opts.exit(opts, depth)
+    end
+    return value
   end
   return repl
 end
@@ -710,14 +743,14 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   local unpack = (table.unpack or _G.unpack)
   local SPECIALS = compiler.scopes.global.specials
   local function wrap_env(env)
-    local function _415_(_, key)
+    local function _417_(_, key)
       if utils["string?"](key) then
         return env[compiler["global-unmangling"](key)]
       else
         return env[key]
       end
     end
-    local function _417_(_, key, value)
+    local function _419_(_, key, value)
       if utils["string?"](key) then
         env[compiler["global-unmangling"](key)] = value
         return nil
@@ -726,26 +759,26 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
         return nil
       end
     end
-    local function _419_()
+    local function _421_()
       local function putenv(k, v)
-        local _420_
+        local _422_
         if utils["string?"](k) then
-          _420_ = compiler["global-unmangling"](k)
+          _422_ = compiler["global-unmangling"](k)
         else
-          _420_ = k
+          _422_ = k
         end
-        return _420_, v
+        return _422_, v
       end
       return next, utils.kvmap(env, putenv), nil
     end
-    return setmetatable({}, {__index = _415_, __newindex = _417_, __pairs = _419_})
+    return setmetatable({}, {__index = _417_, __newindex = _419_, __pairs = _421_})
   end
   local function current_global_names(_3fenv)
     local mt = nil
     do
-      local _422_0 = getmetatable(_3fenv)
-      if ((_G.type(_422_0) == "table") and (nil ~= _422_0.__pairs)) then
-        local mtpairs = _422_0.__pairs
+      local _424_0 = getmetatable(_3fenv)
+      if ((_G.type(_424_0) == "table") and (nil ~= _424_0.__pairs)) then
+        local mtpairs = _424_0.__pairs
         local tbl_14_ = {}
         for k, v in mtpairs(_3fenv) do
           local k_15_, v_16_ = k, v
@@ -754,7 +787,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
           end
         end
         mt = tbl_14_
-      elseif (_422_0 == nil) then
+      elseif (_424_0 == nil) then
         mt = (_3fenv or _G)
       else
       mt = nil
@@ -764,15 +797,15 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local function load_code(code, _3fenv, _3ffilename)
     local env = (_3fenv or rawget(_G, "_ENV") or _G)
-    local _425_0, _426_0 = rawget(_G, "setfenv"), rawget(_G, "loadstring")
-    if ((nil ~= _425_0) and (nil ~= _426_0)) then
-      local setfenv = _425_0
-      local loadstring = _426_0
+    local _427_0, _428_0 = rawget(_G, "setfenv"), rawget(_G, "loadstring")
+    if ((nil ~= _427_0) and (nil ~= _428_0)) then
+      local setfenv = _427_0
+      local loadstring = _428_0
       local f = assert(loadstring(code, _3ffilename))
       setfenv(f, env)
       return f
     else
-      local _ = _425_0
+      local _ = _427_0
       return assert(load(code, _3ffilename, "t", env))
     end
   end
@@ -784,13 +817,13 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
       local mt = getmetatable(tgt)
       if ((type(tgt) == "function") or ((type(mt) == "table") and (type(mt.__call) == "function"))) then
         local arglist = table.concat(((compiler.metadata):get(tgt, "fnl/arglist") or {"#<unknown-arguments>"}), " ")
-        local _428_
+        local _430_
         if (0 < #arglist) then
-          _428_ = " "
+          _430_ = " "
         else
-          _428_ = ""
+          _430_ = ""
         end
-        return string.format("(%s%s%s)\n  %s", name, _428_, arglist, docstring)
+        return string.format("(%s%s%s)\n  %s", name, _430_, arglist, docstring)
       else
         return string.format("%s\n  %s", name, docstring)
       end
@@ -816,16 +849,12 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     local len = #ast
     local retexprs = {returned = true}
     local function compile_body(outer_target, outer_tail, outer_retexprs)
-      if (len < start) then
-        compiler.compile1(nil, sub_scope, chunk, {tail = outer_tail, target = outer_target})
-      else
-        for i = start, len do
-          local subopts = {nval = (((i ~= len) and 0) or opts.nval), tail = (((i == len) and outer_tail) or nil), target = (((i == len) and outer_target) or nil)}
-          local _ = utils["propagate-options"](opts, subopts)
-          local subexprs = compiler.compile1(ast[i], sub_scope, chunk, subopts)
-          if (i ~= len) then
-            compiler["keep-side-effects"](subexprs, parent, nil, ast[i])
-          end
+      for i = start, len do
+        local subopts = {nval = (((i ~= len) and 0) or opts.nval), tail = (((i == len) and outer_tail) or nil), target = (((i == len) and outer_target) or nil)}
+        local _ = utils["propagate-options"](opts, subopts)
+        local subexprs = compiler.compile1(ast[i], sub_scope, chunk, subopts)
+        if (i ~= len) then
+          compiler["keep-side-effects"](subexprs, parent, nil, ast[i])
         end
       end
       compiler.emit(parent, chunk, ast)
@@ -903,9 +932,9 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     local opts = {nval = 1, tail = false}
     local scope = compiler["make-scope"]()
     local chunk = {}
-    local _439_ = compiler.compile1(v, scope, chunk, opts)
-    local _440_ = _439_[1]
-    local v0 = _440_[1]
+    local _440_ = compiler.compile1(v, scope, chunk, opts)
+    local _441_ = _440_[1]
+    local v0 = _441_[1]
     return v0
   end
   local function insert_meta(meta, k, v)
@@ -913,23 +942,23 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     compiler.assert((type(k) == "string"), ("expected string keys in metadata table, got: %s"):format(view(k, view_opts)))
     compiler.assert(literal_3f(v), ("expected literal value in metadata table, got: %s %s"):format(view(k, view_opts), view(v, view_opts)))
     table.insert(meta, view(k))
-    local function _441_()
+    local function _442_()
       if ("string" == type(v)) then
         return view(v, view_opts)
       else
         return compile_value(v)
       end
     end
-    table.insert(meta, _441_())
+    table.insert(meta, _442_())
     return meta
   end
   local function insert_arglist(meta, arg_list)
     local view_opts = {["escape-newlines?"] = true, ["line-length"] = math.huge, ["one-line?"] = true}
     table.insert(meta, "\"fnl/arglist\"")
-    local function _442_(_241)
+    local function _443_(_241)
       return view(view(_241, view_opts))
     end
-    table.insert(meta, ("{" .. table.concat(utils.map(arg_list, _442_), ", ") .. "}"))
+    table.insert(meta, ("{" .. table.concat(utils.map(arg_list, _443_), ", ") .. "}"))
     return meta
   end
   local function set_fn_metadata(f_metadata, parent, fn_name)
@@ -948,13 +977,13 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local function get_fn_name(ast, scope, fn_name, multi)
     if (fn_name and (fn_name[1] ~= "nil")) then
-      local _445_
+      local _446_
       if not multi then
-        _445_ = compiler["declare-local"](fn_name, {}, scope, ast)
+        _446_ = compiler["declare-local"](fn_name, {}, scope, ast)
       else
-        _445_ = compiler["symbol-to-expression"](fn_name, scope)[1]
+        _446_ = compiler["symbol-to-expression"](fn_name, scope)[1]
       end
-      return _445_, not multi, 3
+      return _446_, not multi, 3
     else
       return nil, true, 2
     end
@@ -963,13 +992,13 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     for i = (index + 1), #ast do
       compiler.compile1(ast[i], f_scope, f_chunk, {nval = (((i ~= #ast) and 0) or nil), tail = (i == #ast)})
     end
-    local _448_
+    local _449_
     if local_3f then
-      _448_ = "local function %s(%s)"
+      _449_ = "local function %s(%s)"
     else
-      _448_ = "%s = function(%s)"
+      _449_ = "%s = function(%s)"
     end
-    compiler.emit(parent, string.format(_448_, fn_name, table.concat(arg_name_list, ", ")), ast)
+    compiler.emit(parent, string.format(_449_, fn_name, table.concat(arg_name_list, ", ")), ast)
     compiler.emit(parent, f_chunk, ast)
     compiler.emit(parent, "end", ast)
     set_fn_metadata(f_metadata, parent, fn_name)
@@ -991,7 +1020,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     end
   end
   local function get_function_metadata(ast, arg_list, index)
-    local function _451_(_241, _242)
+    local function _452_(_241, _242)
       local tbl_14_ = _241
       for k, v in pairs(_242) do
         local k_15_, v_16_ = k, v
@@ -1001,18 +1030,18 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
       end
       return tbl_14_
     end
-    local function _453_(_241, _242)
+    local function _454_(_241, _242)
       _241["fnl/docstring"] = _242
       return _241
     end
-    return maybe_metadata(ast, utils["kv-table?"], _451_, maybe_metadata(ast, utils["string?"], _453_, {["fnl/arglist"] = arg_list}, index))
+    return maybe_metadata(ast, utils["kv-table?"], _452_, maybe_metadata(ast, utils["string?"], _454_, {["fnl/arglist"] = arg_list}, index))
   end
   SPECIALS.fn = function(ast, scope, parent)
     local f_scope = nil
     do
-      local _454_0 = compiler["make-scope"](scope)
-      _454_0["vararg"] = false
-      f_scope = _454_0
+      local _455_0 = compiler["make-scope"](scope)
+      _455_0["vararg"] = false
+      f_scope = _455_0
     end
     local f_chunk = {}
     local fn_sym = utils["sym?"](ast[2])
@@ -1072,36 +1101,36 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   doc_special("fn", {"name?", "args", "docstring?", "..."}, "Function syntax. May optionally include a name and docstring or a metadata table.\nIf a name is provided, the function will be bound in the current scope.\nWhen called with the wrong number of args, excess args will be discarded\nand lacking args will be nil, use lambda for arity-checked functions.", true)
   SPECIALS.lua = function(ast, _, parent)
     compiler.assert(((#ast == 2) or (#ast == 3)), "expected 1 or 2 arguments", ast)
-    local _459_
+    local _460_
     do
-      local _458_0 = utils["sym?"](ast[2])
-      if (nil ~= _458_0) then
-        _459_ = tostring(_458_0)
+      local _459_0 = utils["sym?"](ast[2])
+      if (nil ~= _459_0) then
+        _460_ = tostring(_459_0)
       else
-        _459_ = _458_0
+        _460_ = _459_0
       end
     end
-    if ("nil" ~= _459_) then
+    if ("nil" ~= _460_) then
       table.insert(parent, {ast = ast, leaf = tostring(ast[2])})
     end
-    local _463_
+    local _464_
     do
-      local _462_0 = utils["sym?"](ast[3])
-      if (nil ~= _462_0) then
-        _463_ = tostring(_462_0)
+      local _463_0 = utils["sym?"](ast[3])
+      if (nil ~= _463_0) then
+        _464_ = tostring(_463_0)
       else
-        _463_ = _462_0
+        _464_ = _463_0
       end
     end
-    if ("nil" ~= _463_) then
+    if ("nil" ~= _464_) then
       return tostring(ast[3])
     end
   end
   local function dot(ast, scope, parent)
     compiler.assert((1 < #ast), "expected table argument", ast)
     local len = #ast
-    local _466_ = compiler.compile1(ast[2], scope, parent, {nval = 1})
-    local lhs = _466_[1]
+    local _467_ = compiler.compile1(ast[2], scope, parent, {nval = 1})
+    local lhs = _467_[1]
     if (len == 2) then
       return tostring(lhs)
     else
@@ -1111,12 +1140,12 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
         if (utils["string?"](index) and utils["valid-lua-identifier?"](index)) then
           table.insert(indices, ("." .. index))
         else
-          local _467_ = compiler.compile1(index, scope, parent, {nval = 1})
-          local index0 = _467_[1]
+          local _468_ = compiler.compile1(index, scope, parent, {nval = 1})
+          local index0 = _468_[1]
           table.insert(indices, ("[" .. tostring(index0) .. "]"))
         end
       end
-      if (tostring(lhs):find("[{\"0-9]") or ("nil" == tostring(lhs))) then
+      if (not (utils["sym?"](ast[2]) or utils["list?"](ast[2])) or ("nil" == tostring(lhs))) then
         return ("(" .. tostring(lhs) .. ")" .. table.concat(indices))
       else
         return (tostring(lhs) .. table.concat(indices))
@@ -1157,7 +1186,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   doc_special("var", {"name", "val"}, "Introduce new mutable local.")
   local function kv_3f(t)
-    local _471_
+    local _472_
     do
       local tbl_17_ = {}
       local i_18_ = #tbl_17_
@@ -1173,9 +1202,9 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
           tbl_17_[i_18_] = val_19_
         end
       end
-      _471_ = tbl_17_
+      _472_ = tbl_17_
     end
-    return _471_[1]
+    return _472_[1]
   end
   SPECIALS.let = function(ast, scope, parent, opts)
     local bindings = ast[2]
@@ -1202,22 +1231,22 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     end
   end
   local function disambiguate_3f(rootstr, parent)
-    local function _476_()
-      local _475_0 = get_prev_line(parent)
-      if (nil ~= _475_0) then
-        local prev_line = _475_0
+    local function _477_()
+      local _476_0 = get_prev_line(parent)
+      if (nil ~= _476_0) then
+        local prev_line = _476_0
         return prev_line:match("%)$")
       end
     end
-    return (rootstr:match("^{") or rootstr:match("^%(") or _476_())
+    return (rootstr:match("^{") or rootstr:match("^%(") or _477_())
   end
   SPECIALS.tset = function(ast, scope, parent)
     compiler.assert((3 < #ast), "expected table, key, and value arguments", ast)
     local root = compiler.compile1(ast[2], scope, parent, {nval = 1})[1]
     local keys = {}
     for i = 3, (#ast - 1) do
-      local _478_ = compiler.compile1(ast[i], scope, parent, {nval = 1})
-      local key = _478_[1]
+      local _479_ = compiler.compile1(ast[i], scope, parent, {nval = 1})
+      local key = _479_[1]
       table.insert(keys, tostring(key))
     end
     local value = compiler.compile1(ast[#ast], scope, parent, {nval = 1})[1]
@@ -1231,7 +1260,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     return compiler.emit(parent, fmtstr:format(rootstr, table.concat(keys, "]["), tostring(value)), ast)
   end
   doc_special("tset", {"tbl", "key1", "...", "keyN", "val"}, "Set the value of a table field. Can take additional keys to set\nnested values, but all parents must contain an existing table.")
-  local function calculate_target(scope, opts)
+  local function calculate_if_target(scope, opts)
     if not (opts.tail or opts.target or opts.nval) then
       return "iife", true, nil
     elseif (opts.nval and (opts.nval ~= 0) and not opts.target) then
@@ -1249,81 +1278,88 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local function if_2a(ast, scope, parent, opts)
     compiler.assert((2 < #ast), "expected condition and body", ast)
-    local do_scope = compiler["make-scope"](scope)
-    local branches = {}
-    local wrapper, inner_tail, inner_target, target_exprs = calculate_target(scope, opts)
-    local body_opts = {nval = opts.nval, tail = inner_tail, target = inner_target}
-    local function compile_body(i)
-      local chunk = {}
-      local cscope = compiler["make-scope"](do_scope)
-      compiler["keep-side-effects"](compiler.compile1(ast[i], cscope, chunk, body_opts), chunk, nil, ast[i])
-      return {chunk = chunk, scope = cscope}
+    if ((1 == (#ast % 2)) and (ast[(#ast - 1)] == true)) then
+      table.remove(ast, (#ast - 1))
     end
     if (1 == (#ast % 2)) then
       table.insert(ast, utils.sym("nil"))
     end
-    for i = 2, (#ast - 1), 2 do
-      local condchunk = {}
-      local res = compiler.compile1(ast[i], do_scope, condchunk, {nval = 1})
-      local cond = res[1]
-      local branch = compile_body((i + 1))
-      branch.cond = cond
-      branch.condchunk = condchunk
-      branch.nested = ((i ~= 2) and (next(condchunk, nil) == nil))
-      table.insert(branches, branch)
-    end
-    local else_branch = compile_body(#ast)
-    local s = compiler.gensym(scope)
-    local buffer = {}
-    local last_buffer = buffer
-    for i = 1, #branches do
-      local branch = branches[i]
-      local fstr = nil
-      if not branch.nested then
-        fstr = "if %s then"
-      else
-        fstr = "elseif %s then"
+    if (#ast == 2) then
+      return SPECIALS["do"](utils.list(utils.sym("do"), ast[2]), scope, parent, opts)
+    else
+      local do_scope = compiler["make-scope"](scope)
+      local branches = {}
+      local wrapper, inner_tail, inner_target, target_exprs = calculate_if_target(scope, opts)
+      local body_opts = {nval = opts.nval, tail = inner_tail, target = inner_target}
+      local function compile_body(i)
+        local chunk = {}
+        local cscope = compiler["make-scope"](do_scope)
+        compiler["keep-side-effects"](compiler.compile1(ast[i], cscope, chunk, body_opts), chunk, nil, ast[i])
+        return {chunk = chunk, scope = cscope}
       end
-      local cond = tostring(branch.cond)
-      local cond_line = fstr:format(cond)
-      if branch.nested then
-        compiler.emit(last_buffer, branch.condchunk, ast)
-      else
-        for _, v in ipairs(branch.condchunk) do
-          compiler.emit(last_buffer, v, ast)
+      for i = 2, (#ast - 1), 2 do
+        local condchunk = {}
+        local res = compiler.compile1(ast[i], do_scope, condchunk, {nval = 1})
+        local cond = res[1]
+        local branch = compile_body((i + 1))
+        branch.cond = cond
+        branch.condchunk = condchunk
+        branch.nested = ((i ~= 2) and (next(condchunk, nil) == nil))
+        table.insert(branches, branch)
+      end
+      local else_branch = compile_body(#ast)
+      local s = compiler.gensym(scope)
+      local buffer = {}
+      local last_buffer = buffer
+      for i = 1, #branches do
+        local branch = branches[i]
+        local fstr = nil
+        if not branch.nested then
+          fstr = "if %s then"
+        else
+          fstr = "elseif %s then"
+        end
+        local cond = tostring(branch.cond)
+        local cond_line = fstr:format(cond)
+        if branch.nested then
+          compiler.emit(last_buffer, branch.condchunk, ast)
+        else
+          for _, v in ipairs(branch.condchunk) do
+            compiler.emit(last_buffer, v, ast)
+          end
+        end
+        compiler.emit(last_buffer, cond_line, ast)
+        compiler.emit(last_buffer, branch.chunk, ast)
+        if (i == #branches) then
+          compiler.emit(last_buffer, "else", ast)
+          compiler.emit(last_buffer, else_branch.chunk, ast)
+          compiler.emit(last_buffer, "end", ast)
+        elseif not branches[(i + 1)].nested then
+          local next_buffer = {}
+          compiler.emit(last_buffer, "else", ast)
+          compiler.emit(last_buffer, next_buffer, ast)
+          compiler.emit(last_buffer, "end", ast)
+          last_buffer = next_buffer
         end
       end
-      compiler.emit(last_buffer, cond_line, ast)
-      compiler.emit(last_buffer, branch.chunk, ast)
-      if (i == #branches) then
-        compiler.emit(last_buffer, "else", ast)
-        compiler.emit(last_buffer, else_branch.chunk, ast)
-        compiler.emit(last_buffer, "end", ast)
-      elseif not branches[(i + 1)].nested then
-        local next_buffer = {}
-        compiler.emit(last_buffer, "else", ast)
-        compiler.emit(last_buffer, next_buffer, ast)
-        compiler.emit(last_buffer, "end", ast)
-        last_buffer = next_buffer
+      if (wrapper == "iife") then
+        local iifeargs = ((scope.vararg and "...") or "")
+        compiler.emit(parent, ("local function %s(%s)"):format(tostring(s), iifeargs), ast)
+        compiler.emit(parent, buffer, ast)
+        compiler.emit(parent, "end", ast)
+        return utils.expr(("%s(%s)"):format(tostring(s), iifeargs), "statement")
+      elseif (wrapper == "none") then
+        for i = 1, #buffer do
+          compiler.emit(parent, buffer[i], ast)
+        end
+        return {returned = true}
+      else
+        compiler.emit(parent, ("local %s"):format(inner_target), ast)
+        for i = 1, #buffer do
+          compiler.emit(parent, buffer[i], ast)
+        end
+        return target_exprs
       end
-    end
-    if (wrapper == "iife") then
-      local iifeargs = ((scope.vararg and "...") or "")
-      compiler.emit(parent, ("local function %s(%s)"):format(tostring(s), iifeargs), ast)
-      compiler.emit(parent, buffer, ast)
-      compiler.emit(parent, "end", ast)
-      return utils.expr(("%s(%s)"):format(tostring(s), iifeargs), "statement")
-    elseif (wrapper == "none") then
-      for i = 1, #buffer do
-        compiler.emit(parent, buffer[i], ast)
-      end
-      return {returned = true}
-    else
-      compiler.emit(parent, ("local %s"):format(inner_target), ast)
-      for i = 1, #buffer do
-        compiler.emit(parent, buffer[i], ast)
-      end
-      return target_exprs
     end
   end
   SPECIALS["if"] = if_2a
@@ -1337,15 +1373,14 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local function compile_until(condition, scope, chunk)
     if condition then
-      local _487_ = compiler.compile1(condition, scope, chunk, {nval = 1})
-      local condition_lua = _487_[1]
+      local _490_ = compiler.compile1(condition, scope, chunk, {nval = 1})
+      local condition_lua = _490_[1]
       return compiler.emit(chunk, ("if %s then break end"):format(tostring(condition_lua)), utils.expr(condition, "expression"))
     end
   end
   SPECIALS.each = function(ast, scope, parent)
     compiler.assert((3 <= #ast), "expected body expression", ast[1])
     compiler.assert(utils["table?"](ast[2]), "expected binding table", ast)
-    compiler.assert((2 <= #ast[2]), "expected binding and iterator", ast)
     local binding = setmetatable(utils.copy(ast[2]), getmetatable(ast[2]))
     local until_condition = remove_until_condition(binding)
     local iter = table.remove(binding, #binding)
@@ -1366,6 +1401,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     local vals = compiler.compile1(iter, scope, parent)
     local val_names = utils.map(vals, tostring)
     local chunk = {}
+    compiler.assert(bind_vars[1], "expected binding and iterator", ast)
     compiler.emit(parent, ("for %s in %s do"):format(table.concat(bind_vars, ", "), table.concat(val_names, ", ")), ast)
     for raw, args in utils.stablepairs(destructures) do
       compiler.destructure(args, raw, ast, sub_scope, chunk, {declaration = true, nomulti = true, symtype = "each"})
@@ -1422,10 +1458,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   SPECIALS["for"] = for_2a
   doc_special("for", {"[index start stop step?]", "..."}, "Numeric loop construct.\nEvaluates body once for each value between start and stop (inclusive).", true)
   local function native_method_call(ast, _scope, _parent, target, args)
-    local _491_ = ast
-    local _ = _491_[1]
-    local _0 = _491_[2]
-    local method_string = _491_[3]
+    local _494_ = ast
+    local _ = _494_[1]
+    local _0 = _494_[2]
+    local method_string = _494_[3]
     local call_string = nil
     if ((target.type == "literal") or (target.type == "varg") or (target.type == "expression")) then
       call_string = "(%s):%s(%s)"
@@ -1447,18 +1483,18 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local function method_call(ast, scope, parent)
     compiler.assert((2 < #ast), "expected at least 2 arguments", ast)
-    local _493_ = compiler.compile1(ast[2], scope, parent, {nval = 1})
-    local target = _493_[1]
+    local _496_ = compiler.compile1(ast[2], scope, parent, {nval = 1})
+    local target = _496_[1]
     local args = {}
     for i = 4, #ast do
       local subexprs = nil
-      local _494_
+      local _497_
       if (i ~= #ast) then
-        _494_ = 1
+        _497_ = 1
       else
-      _494_ = nil
+      _497_ = nil
       end
-      subexprs = compiler.compile1(ast[i], scope, parent, {nval = _494_})
+      subexprs = compiler.compile1(ast[i], scope, parent, {nval = _497_})
       utils.map(subexprs, tostring, args)
     end
     if (utils["string?"](ast[3]) and utils["valid-lua-identifier?"](ast[3])) then
@@ -1473,14 +1509,14 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   doc_special(":", {"tbl", "method-name", "..."}, "Call the named method on tbl with the provided args.\nMethod name doesn't have to be known at compile-time; if it is, use\n(tbl:method-name ...) instead.")
   SPECIALS.comment = function(ast, _, parent)
     local c = nil
-    local _497_
+    local _500_
     do
       local tbl_17_ = {}
       local i_18_ = #tbl_17_
       for i, elt in ipairs(ast) do
         local val_19_ = nil
         if (i ~= 1) then
-          val_19_ = view(ast[i], {["one-line?"] = true})
+          val_19_ = view(elt, {["one-line?"] = true})
         else
         val_19_ = nil
         end
@@ -1489,9 +1525,9 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
           tbl_17_[i_18_] = val_19_
         end
       end
-      _497_ = tbl_17_
+      _500_ = tbl_17_
     end
-    c = table.concat(_497_, " "):gsub("%]%]", "]\\]")
+    c = table.concat(_500_, " "):gsub("%]%]", "]\\]")
     return compiler.emit(parent, ("--[[ " .. c .. " ]]"), ast)
   end
   doc_special("comment", {"..."}, "Comment which will be emitted in Lua output.", true)
@@ -1512,10 +1548,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     compiler.assert((#ast == 2), "expected one argument", ast)
     local f_scope = nil
     do
-      local _502_0 = compiler["make-scope"](scope)
-      _502_0["vararg"] = false
-      _502_0["hashfn"] = true
-      f_scope = _502_0
+      local _505_0 = compiler["make-scope"](scope)
+      _505_0["vararg"] = false
+      _505_0["hashfn"] = true
+      f_scope = _505_0
     end
     local f_chunk = {}
     local name = compiler.gensym(scope)
@@ -1556,17 +1592,17 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     return utils.expr(name, "sym")
   end
   doc_special("hashfn", {"..."}, "Function literal shorthand; args are either $... OR $1, $2, etc.")
-  local function maybe_short_circuit_protect(ast, i, name, _507_0)
-    local _508_ = _507_0
-    local mac = _508_["macros"]
+  local function maybe_short_circuit_protect(ast, i, name, _510_0)
+    local _511_ = _510_0
+    local mac = _511_["macros"]
     local call = (utils["list?"](ast) and tostring(ast[1]))
     if ((("or" == name) or ("and" == name)) and (1 < i) and (mac[call] or ("set" == call) or ("tset" == call) or ("global" == call))) then
-      return utils.list(utils.sym("do"), ast)
+      return utils.list(utils.list(utils.sym("fn"), utils.sequence(utils.varg()), ast))
     else
       return ast
     end
   end
-  local function arithmetic_special(name, zero_arity, unary_prefix, ast, scope, parent)
+  local function operator_special(name, zero_arity, unary_prefix, ast, scope, parent)
     local len = #ast
     local operands = {}
     local padded_op = (" " .. name .. " ")
@@ -1579,15 +1615,15 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
         table.insert(operands, tostring(subexprs[1]))
       end
     end
-    local _511_0 = #operands
-    if (_511_0 == 0) then
-      local _512_
+    local _514_0 = #operands
+    if (_514_0 == 0) then
+      local _515_
       do
         compiler.assert(zero_arity, "Expected more than 0 arguments", ast)
-        _512_ = zero_arity
+        _515_ = zero_arity
       end
-      return utils.expr(_512_, "literal")
-    elseif (_511_0 == 1) then
+      return utils.expr(_515_, "literal")
+    elseif (_514_0 == 1) then
       if utils["varg?"](ast[2]) then
         return compiler.assert(false, "tried to use vararg with operator", ast)
       elseif unary_prefix then
@@ -1596,20 +1632,20 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
         return operands[1]
       end
     else
-      local _ = _511_0
+      local _ = _514_0
       return ("(" .. table.concat(operands, padded_op) .. ")")
     end
   end
   local function define_arithmetic_special(name, zero_arity, unary_prefix, _3flua_name)
-    local _516_
+    local _519_
     do
-      local _515_0 = (_3flua_name or name)
-      local function _517_(...)
-        return arithmetic_special(_515_0, zero_arity, unary_prefix, ...)
+      local _518_0 = (_3flua_name or name)
+      local function _520_(...)
+        return operator_special(_518_0, zero_arity, unary_prefix, ...)
       end
-      _516_ = _517_
+      _519_ = _520_
     end
-    SPECIALS[name] = _516_
+    SPECIALS[name] = _519_
     return doc_special(name, {"a", "b", "..."}, "Arithmetic operator; works the same as Lua but accepts more arguments.")
   end
   define_arithmetic_special("+", "0")
@@ -1621,10 +1657,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   define_arithmetic_special("/", nil, "1")
   define_arithmetic_special("//", nil, "1")
   SPECIALS["or"] = function(ast, scope, parent)
-    return arithmetic_special("or", "false", nil, ast, scope, parent)
+    return operator_special("or", "false", nil, ast, scope, parent)
   end
   SPECIALS["and"] = function(ast, scope, parent)
-    return arithmetic_special("and", "true", nil, ast, scope, parent)
+    return operator_special("and", "true", nil, ast, scope, parent)
   end
   doc_special("and", {"a", "b", "..."}, "Boolean operator; works the same as Lua but accepts more arguments.")
   doc_special("or", {"a", "b", "..."}, "Boolean operator; works the same as Lua but accepts more arguments.")
@@ -1638,13 +1674,13 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
       local prefixed_lib_name = ("bit." .. lib_name)
       for i = 2, len do
         local subexprs = nil
-        local _518_
+        local _521_
         if (i ~= len) then
-          _518_ = 1
+          _521_ = 1
         else
-        _518_ = nil
+        _521_ = nil
         end
-        subexprs = compiler.compile1(ast[i], scope, parent, {nval = _518_})
+        subexprs = compiler.compile1(ast[i], scope, parent, {nval = _521_})
         utils.map(subexprs, tostring, operands)
       end
       if (#operands == 1) then
@@ -1663,10 +1699,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     end
   end
   local function define_bitop_special(name, zero_arity, unary_prefix, native)
-    local function _524_(...)
+    local function _527_(...)
       return bitop_special(native, name, zero_arity, unary_prefix, ...)
     end
-    SPECIALS[name] = _524_
+    SPECIALS[name] = _527_
     return nil
   end
   define_bitop_special("lshift", nil, "1", "<<")
@@ -1681,8 +1717,8 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   doc_special("bxor", {"x1", "x2", "..."}, "Bitwise XOR of any number of arguments.\nOnly works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
   SPECIALS.bnot = function(ast, scope, parent)
     compiler.assert((#ast == 2), "expected one argument", ast)
-    local _525_ = compiler.compile1(ast[2], scope, parent, {nval = 1})
-    local value = _525_[1]
+    local _528_ = compiler.compile1(ast[2], scope, parent, {nval = 1})
+    local value = _528_[1]
     if utils.root.options.useBitLib then
       return ("bit.bnot(" .. tostring(value) .. ")")
     else
@@ -1691,15 +1727,15 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   doc_special("bnot", {"x"}, "Bitwise negation; only works in Lua 5.3+ or LuaJIT with the --use-bit-lib flag.")
   doc_special("..", {"a", "b", "..."}, "String concatenation operator; works the same as Lua but accepts more arguments.")
-  local function native_comparator(op, _527_0, scope, parent)
-    local _528_ = _527_0
-    local _ = _528_[1]
-    local lhs_ast = _528_[2]
-    local rhs_ast = _528_[3]
-    local _529_ = compiler.compile1(lhs_ast, scope, parent, {nval = 1})
-    local lhs = _529_[1]
-    local _530_ = compiler.compile1(rhs_ast, scope, parent, {nval = 1})
-    local rhs = _530_[1]
+  local function native_comparator(op, _530_0, scope, parent)
+    local _531_ = _530_0
+    local _ = _531_[1]
+    local lhs_ast = _531_[2]
+    local rhs_ast = _531_[3]
+    local _532_ = compiler.compile1(lhs_ast, scope, parent, {nval = 1})
+    local lhs = _532_[1]
+    local _533_ = compiler.compile1(rhs_ast, scope, parent, {nval = 1})
+    local rhs = _533_[1]
     return string.format("(%s %s %s)", tostring(lhs), op, tostring(rhs))
   end
   local function idempotent_comparator(op, chain_op, ast, scope, parent)
@@ -1812,21 +1848,21 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local safe_require = nil
   local function safe_compiler_env()
-    local _537_
+    local _540_
     do
-      local _536_0 = rawget(_G, "utf8")
-      if (nil ~= _536_0) then
-        _537_ = utils.copy(_536_0)
+      local _539_0 = rawget(_G, "utf8")
+      if (nil ~= _539_0) then
+        _540_ = utils.copy(_539_0)
       else
-        _537_ = _536_0
+        _540_ = _539_0
       end
     end
-    return {_VERSION = _VERSION, assert = assert, bit = rawget(_G, "bit"), error = error, getmetatable = safe_getmetatable, ipairs = ipairs, math = utils.copy(math), next = next, pairs = utils.stablepairs, pcall = pcall, print = print, rawequal = rawequal, rawget = rawget, rawlen = rawget(_G, "rawlen"), rawset = rawset, require = safe_require, select = select, setmetatable = setmetatable, string = utils.copy(string), table = utils.copy(table), tonumber = tonumber, tostring = tostring, type = type, utf8 = _537_, xpcall = xpcall}
+    return {_VERSION = _VERSION, assert = assert, bit = rawget(_G, "bit"), error = error, getmetatable = safe_getmetatable, ipairs = ipairs, math = utils.copy(math), next = next, pairs = utils.stablepairs, pcall = pcall, print = print, rawequal = rawequal, rawget = rawget, rawlen = rawget(_G, "rawlen"), rawset = rawset, require = safe_require, select = select, setmetatable = setmetatable, string = utils.copy(string), table = utils.copy(table), tonumber = tonumber, tostring = tostring, type = type, utf8 = _540_, xpcall = xpcall}
   end
   local function combined_mt_pairs(env)
     local combined = {}
-    local _539_ = getmetatable(env)
-    local __index = _539_["__index"]
+    local _542_ = getmetatable(env)
+    local __index = _542_["__index"]
     if ("table" == type(__index)) then
       for k, v in pairs(__index) do
         combined[k] = v
@@ -1840,40 +1876,40 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   local function make_compiler_env(ast, scope, parent, _3fopts)
     local provided = nil
     do
-      local _541_0 = (_3fopts or utils.root.options)
-      if ((_G.type(_541_0) == "table") and (_541_0["compiler-env"] == "strict")) then
+      local _544_0 = (_3fopts or utils.root.options)
+      if ((_G.type(_544_0) == "table") and (_544_0["compiler-env"] == "strict")) then
         provided = safe_compiler_env()
-      elseif ((_G.type(_541_0) == "table") and (nil ~= _541_0.compilerEnv)) then
-        local compilerEnv = _541_0.compilerEnv
+      elseif ((_G.type(_544_0) == "table") and (nil ~= _544_0.compilerEnv)) then
+        local compilerEnv = _544_0.compilerEnv
         provided = compilerEnv
-      elseif ((_G.type(_541_0) == "table") and (nil ~= _541_0["compiler-env"])) then
-        local compiler_env = _541_0["compiler-env"]
+      elseif ((_G.type(_544_0) == "table") and (nil ~= _544_0["compiler-env"])) then
+        local compiler_env = _544_0["compiler-env"]
         provided = compiler_env
       else
-        local _ = _541_0
-        provided = safe_compiler_env(false)
+        local _ = _544_0
+        provided = safe_compiler_env()
       end
     end
     local env = nil
-    local function _543_()
+    local function _546_()
       return compiler.scopes.macro
     end
-    local function _544_(symbol)
+    local function _547_(symbol)
       compiler.assert(compiler.scopes.macro, "must call from macro", ast)
       return compiler.scopes.macro.manglings[tostring(symbol)]
     end
-    local function _545_(base)
+    local function _548_(base)
       return utils.sym(compiler.gensym((compiler.scopes.macro or scope), base))
     end
-    local function _546_(form)
+    local function _549_(form)
       compiler.assert(compiler.scopes.macro, "must call from macro", ast)
       return compiler.macroexpand(form, compiler.scopes.macro)
     end
-    env = {["assert-compile"] = compiler.assert, ["ast-source"] = utils["ast-source"], ["comment?"] = utils["comment?"], ["get-scope"] = _543_, ["in-scope?"] = _544_, ["list?"] = utils["list?"], ["macro-loaded"] = macro_loaded, ["multi-sym?"] = utils["multi-sym?"], ["sequence?"] = utils["sequence?"], ["sym?"] = utils["sym?"], ["table?"] = utils["table?"], ["varg?"] = utils["varg?"], _AST = ast, _CHUNK = parent, _IS_COMPILER = true, _SCOPE = scope, _SPECIALS = compiler.scopes.global.specials, _VARARG = utils.varg(), comment = utils.comment, gensym = _545_, list = utils.list, macroexpand = _546_, metadata = compiler.metadata, sequence = utils.sequence, sym = utils.sym, unpack = unpack, version = utils.version, view = view}
+    env = {["assert-compile"] = compiler.assert, ["ast-source"] = utils["ast-source"], ["comment?"] = utils["comment?"], ["get-scope"] = _546_, ["in-scope?"] = _547_, ["list?"] = utils["list?"], ["macro-loaded"] = macro_loaded, ["multi-sym?"] = utils["multi-sym?"], ["sequence?"] = utils["sequence?"], ["sym?"] = utils["sym?"], ["table?"] = utils["table?"], ["varg?"] = utils["varg?"], _AST = ast, _CHUNK = parent, _IS_COMPILER = true, _SCOPE = scope, _SPECIALS = compiler.scopes.global.specials, _VARARG = utils.varg(), comment = utils.comment, gensym = _548_, list = utils.list, macroexpand = _549_, sequence = utils.sequence, sym = utils.sym, unpack = unpack, version = utils.version, view = view}
     env._G = env
     return setmetatable(env, {__index = provided, __newindex = provided, __pairs = combined_mt_pairs})
   end
-  local function _547_(...)
+  local function _550_(...)
     local tbl_17_ = {}
     local i_18_ = #tbl_17_
     for c in string.gmatch((package.config or ""), "([^\n]+)") do
@@ -1885,10 +1921,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     end
     return tbl_17_
   end
-  local _549_ = _547_(...)
-  local dirsep = _549_[1]
-  local pathsep = _549_[2]
-  local pathmark = _549_[3]
+  local _552_ = _550_(...)
+  local dirsep = _552_[1]
+  local pathsep = _552_[2]
+  local pathmark = _552_[3]
   local pkg_config = {dirsep = (dirsep or "/"), pathmark = (pathmark or "?"), pathsep = (pathsep or ";")}
   local function escapepat(str)
     return string.gsub(str, "[^%w]", "%%%1")
@@ -1901,36 +1937,36 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     local function try_path(path)
       local filename = path:gsub(escapepat(pkg_config.pathmark), no_dot_module)
       local filename2 = path:gsub(escapepat(pkg_config.pathmark), modulename)
-      local _550_0 = (io.open(filename) or io.open(filename2))
-      if (nil ~= _550_0) then
-        local file = _550_0
+      local _553_0 = (io.open(filename) or io.open(filename2))
+      if (nil ~= _553_0) then
+        local file = _553_0
         file:close()
         return filename
       else
-        local _ = _550_0
+        local _ = _553_0
         return nil, ("no file '" .. filename .. "'")
       end
     end
     local function find_in_path(start, _3ftried_paths)
-      local _552_0 = fullpath:match(pattern, start)
-      if (nil ~= _552_0) then
-        local path = _552_0
-        local _553_0, _554_0 = try_path(path)
-        if (nil ~= _553_0) then
-          local filename = _553_0
+      local _555_0 = fullpath:match(pattern, start)
+      if (nil ~= _555_0) then
+        local path = _555_0
+        local _556_0, _557_0 = try_path(path)
+        if (nil ~= _556_0) then
+          local filename = _556_0
           return filename
-        elseif ((_553_0 == nil) and (nil ~= _554_0)) then
-          local error = _554_0
-          local function _556_()
-            local _555_0 = (_3ftried_paths or {})
-            table.insert(_555_0, error)
-            return _555_0
+        elseif ((_556_0 == nil) and (nil ~= _557_0)) then
+          local error = _557_0
+          local function _559_()
+            local _558_0 = (_3ftried_paths or {})
+            table.insert(_558_0, error)
+            return _558_0
           end
-          return find_in_path((start + #path + 1), _556_())
+          return find_in_path((start + #path + 1), _559_())
         end
       else
-        local _ = _552_0
-        local function _558_()
+        local _ = _555_0
+        local function _561_()
           local tried_paths = table.concat((_3ftried_paths or {}), "\n\9")
           if (_VERSION < "Lua 5.4") then
             return ("\n\9" .. tried_paths)
@@ -1938,31 +1974,31 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
             return tried_paths
           end
         end
-        return nil, _558_()
+        return nil, _561_()
       end
     end
     return find_in_path(1)
   end
   local function make_searcher(_3foptions)
-    local function _561_(module_name)
+    local function _564_(module_name)
       local opts = utils.copy(utils.root.options)
       for k, v in pairs((_3foptions or {})) do
         opts[k] = v
       end
       opts["module-name"] = module_name
-      local _562_0, _563_0 = search_module(module_name)
-      if (nil ~= _562_0) then
-        local filename = _562_0
-        local function _564_(...)
+      local _565_0, _566_0 = search_module(module_name)
+      if (nil ~= _565_0) then
+        local filename = _565_0
+        local function _567_(...)
           return utils["fennel-module"].dofile(filename, opts, ...)
         end
-        return _564_, filename
-      elseif ((_562_0 == nil) and (nil ~= _563_0)) then
-        local error = _563_0
+        return _567_, filename
+      elseif ((_565_0 == nil) and (nil ~= _566_0)) then
+        local error = _566_0
         return error
       end
     end
-    return _561_
+    return _564_
   end
   local function dofile_with_searcher(fennel_macro_searcher, filename, opts, ...)
     local searchers = (package.loaders or package.searchers or {})
@@ -1974,35 +2010,35 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   local function fennel_macro_searcher(module_name)
     local opts = nil
     do
-      local _566_0 = utils.copy(utils.root.options)
-      _566_0["module-name"] = module_name
-      _566_0["env"] = "_COMPILER"
-      _566_0["requireAsInclude"] = false
-      _566_0["allowedGlobals"] = nil
-      opts = _566_0
+      local _569_0 = utils.copy(utils.root.options)
+      _569_0["module-name"] = module_name
+      _569_0["env"] = "_COMPILER"
+      _569_0["requireAsInclude"] = false
+      _569_0["allowedGlobals"] = nil
+      opts = _569_0
     end
-    local _567_0 = search_module(module_name, utils["fennel-module"]["macro-path"])
-    if (nil ~= _567_0) then
-      local filename = _567_0
-      local _568_
+    local _570_0 = search_module(module_name, utils["fennel-module"]["macro-path"])
+    if (nil ~= _570_0) then
+      local filename = _570_0
+      local _571_
       if (opts["compiler-env"] == _G) then
-        local function _569_(...)
+        local function _572_(...)
           return dofile_with_searcher(fennel_macro_searcher, filename, opts, ...)
         end
-        _568_ = _569_
+        _571_ = _572_
       else
-        local function _570_(...)
+        local function _573_(...)
           return utils["fennel-module"].dofile(filename, opts, ...)
         end
-        _568_ = _570_
+        _571_ = _573_
       end
-      return _568_, filename
+      return _571_, filename
     end
   end
   local function lua_macro_searcher(module_name)
-    local _573_0 = search_module(module_name, package.path)
-    if (nil ~= _573_0) then
-      local filename = _573_0
+    local _576_0 = search_module(module_name, package.path)
+    if (nil ~= _576_0) then
+      local filename = _576_0
       local code = nil
       do
         local f = io.open(filename)
@@ -2014,10 +2050,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
             return error(..., 0)
           end
         end
-        local function _575_()
+        local function _578_()
           return assert(f:read("*a"))
         end
-        code = close_handlers_10_(_G.xpcall(_575_, (package.loaded.fennel or debug).traceback))
+        code = close_handlers_10_(_G.xpcall(_578_, (package.loaded.fennel or debug).traceback))
       end
       local chunk = load_code(code, make_compiler_env(), filename)
       return chunk, filename
@@ -2025,35 +2061,38 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
   end
   local macro_searchers = {fennel_macro_searcher, lua_macro_searcher}
   local function search_macro_module(modname, n)
-    local _577_0 = macro_searchers[n]
-    if (nil ~= _577_0) then
-      local f = _577_0
-      local _578_0, _579_0 = f(modname)
-      if ((nil ~= _578_0) and true) then
-        local loader = _578_0
-        local _3ffilename = _579_0
+    local _580_0 = macro_searchers[n]
+    if (nil ~= _580_0) then
+      local f = _580_0
+      local _581_0, _582_0 = f(modname)
+      if ((nil ~= _581_0) and true) then
+        local loader = _581_0
+        local _3ffilename = _582_0
         return loader, _3ffilename
       else
-        local _ = _578_0
+        local _ = _581_0
         return search_macro_module(modname, (n + 1))
       end
     end
   end
   local function sandbox_fennel_module(modname)
     if ((modname == "fennel.macros") or (package and package.loaded and ("table" == type(package.loaded[modname])) and (package.loaded[modname].metadata == compiler.metadata))) then
-      return {metadata = compiler.metadata, view = view}
+      local function _585_(_, ...)
+        return (compiler.metadata):setall(...)
+      end
+      return {metadata = {setall = _585_}, view = view}
     end
   end
-  local function _583_(modname)
-    local function _584_()
+  local function _587_(modname)
+    local function _588_()
       local loader, filename = search_macro_module(modname, 1)
       compiler.assert(loader, (modname .. " module not found."))
       macro_loaded[modname] = loader(modname, filename)
       return macro_loaded[modname]
     end
-    return (macro_loaded[modname] or sandbox_fennel_module(modname) or _584_())
+    return (macro_loaded[modname] or sandbox_fennel_module(modname) or _588_())
   end
-  safe_require = _583_
+  safe_require = _587_
   local function add_macros(macros_2a, ast, scope)
     compiler.assert(utils["table?"](macros_2a), "expected macros to be table", ast)
     for k, v in pairs(macros_2a) do
@@ -2063,10 +2102,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     end
     return nil
   end
-  local function resolve_module_name(_585_0, _scope, _parent, opts)
-    local _586_ = _585_0
-    local second = _586_[2]
-    local filename = _586_["filename"]
+  local function resolve_module_name(_589_0, _scope, _parent, opts)
+    local _590_ = _589_0
+    local second = _590_[2]
+    local filename = _590_["filename"]
     local filename0 = (filename or (utils["table?"](second) and second.filename))
     local module_name = utils.root.options["module-name"]
     local modexpr = compiler.compile(second, opts)
@@ -2085,7 +2124,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     if ("import-macros" == tostring(ast[1])) then
       return macro_loaded[modname]
     else
-      return add_macros(macro_loaded[modname], ast, scope, parent)
+      return add_macros(macro_loaded[modname], ast, scope)
     end
   end
   doc_special("require-macros", {"macro-module-name"}, "Load given module and use its contents as macro definitions in current scope.\nMacro module should return a table of macro functions with string keys.\nConsider using import-macros instead as it is more flexible.")
@@ -2123,10 +2162,10 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
           return error(..., 0)
         end
       end
-      local function _592_()
+      local function _596_()
         return assert(f:read("*all")):gsub("[\13\n]*$", "")
       end
-      src = close_handlers_10_(_G.xpcall(_592_, (package.loaded.fennel or debug).traceback))
+      src = close_handlers_10_(_G.xpcall(_596_, (package.loaded.fennel or debug).traceback))
     end
     local ret = utils.expr(("require(\"" .. mod .. "\")"), "statement")
     local target = ("package.preload[%q]"):format(mod)
@@ -2156,12 +2195,12 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     compiler.assert((#ast == 2), "expected one argument", ast)
     local modexpr = nil
     do
-      local _595_0, _596_0 = pcall(resolve_module_name, ast, scope, parent, opts)
-      if ((_595_0 == true) and (nil ~= _596_0)) then
-        local modname = _596_0
+      local _599_0, _600_0 = pcall(resolve_module_name, ast, scope, parent, opts)
+      if ((_599_0 == true) and (nil ~= _600_0)) then
+        local modname = _600_0
         modexpr = utils.expr(string.format("%q", modname), "literal")
       else
-        local _ = _595_0
+        local _ = _599_0
         modexpr = compiler.compile1(ast[2], scope, parent, {nval = 1})[1]
       end
     end
@@ -2178,13 +2217,13 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
       utils.root.options["module-name"] = mod
       _ = nil
       local res = nil
-      local function _600_()
-        local _599_0 = search_module(mod)
-        if (nil ~= _599_0) then
-          local fennel_path = _599_0
+      local function _604_()
+        local _603_0 = search_module(mod)
+        if (nil ~= _603_0) then
+          local fennel_path = _603_0
           return include_path(ast, opts, fennel_path, mod, true)
         else
-          local _0 = _599_0
+          local _0 = _603_0
           local lua_path = search_module(mod, package.path)
           if lua_path then
             return include_path(ast, opts, lua_path, mod, false)
@@ -2195,7 +2234,7 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
           end
         end
       end
-      res = ((utils["member?"](mod, (utils.root.options.skipInclude or {})) and opts.fallback(modexpr, true)) or include_circular_fallback(mod, modexpr, opts.fallback, ast) or utils.root.scope.includes[mod] or _600_())
+      res = ((utils["member?"](mod, (utils.root.options.skipInclude or {})) and opts.fallback(modexpr, true)) or include_circular_fallback(mod, modexpr, opts.fallback, ast) or utils.root.scope.includes[mod] or _604_())
       utils.root.options["module-name"] = oldmod
       return res
     end
@@ -2212,9 +2251,18 @@ package.preload["fennel.specials"] = package.preload["fennel.specials"] or funct
     compiler.assert((#ast == 2), "Expected one table argument", ast)
     local macro_tbl = eval_compiler_2a(ast[2], scope, parent)
     compiler.assert(utils["table?"](macro_tbl), "Expected one table argument", ast)
-    return add_macros(macro_tbl, ast, scope, parent)
+    return add_macros(macro_tbl, ast, scope)
   end
   doc_special("macros", {"{:macro-name-1 (fn [...] ...) ... :macro-name-N macro-body-N}"}, "Define all functions in the given table as macros local to the current scope.")
+  SPECIALS["tail!"] = function(ast, scope, _parent, _608_0)
+    local _609_ = _608_0
+    local tail = _609_["tail"]
+    compiler.assert((#ast == 2), "Expected one argument", ast)
+    compiler.assert(utils["list?"](ast[2]), "Expected a call as argument", ast)
+    compiler.assert(tail, "Must be in tail position", ast)
+    return compiler.compile(ast[2], {nval = 1, scope = scope})
+  end
+  doc_special("tail!", {"body"}, "Assert that the body being called is in tail position.")
   SPECIALS["eval-compiler"] = function(ast, scope, parent)
     local old_first = ast[1]
     ast[1] = utils.sym("do")
@@ -2237,13 +2285,13 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   local scopes = {}
   local function make_scope(_3fparent)
     local parent = (_3fparent or scopes.global)
-    local _260_
+    local _261_
     if parent then
-      _260_ = ((parent.depth or 0) + 1)
+      _261_ = ((parent.depth or 0) + 1)
     else
-      _260_ = 0
+      _261_ = 0
     end
-    return {["gensym-base"] = setmetatable({}, {__index = (parent and parent["gensym-base"])}), autogensyms = setmetatable({}, {__index = (parent and parent.autogensyms)}), depth = _260_, gensyms = setmetatable({}, {__index = (parent and parent.gensyms)}), hashfn = (parent and parent.hashfn), includes = setmetatable({}, {__index = (parent and parent.includes)}), macros = setmetatable({}, {__index = (parent and parent.macros)}), manglings = setmetatable({}, {__index = (parent and parent.manglings)}), parent = parent, refedglobals = {}, specials = setmetatable({}, {__index = (parent and parent.specials)}), symmeta = setmetatable({}, {__index = (parent and parent.symmeta)}), unmanglings = setmetatable({}, {__index = (parent and parent.unmanglings)}), vararg = (parent and parent.vararg)}
+    return {["gensym-base"] = setmetatable({}, {__index = (parent and parent["gensym-base"])}), autogensyms = setmetatable({}, {__index = (parent and parent.autogensyms)}), depth = _261_, gensyms = setmetatable({}, {__index = (parent and parent.gensyms)}), hashfn = (parent and parent.hashfn), includes = setmetatable({}, {__index = (parent and parent.includes)}), macros = setmetatable({}, {__index = (parent and parent.macros)}), manglings = setmetatable({}, {__index = (parent and parent.manglings)}), parent = parent, refedglobals = {}, specials = setmetatable({}, {__index = (parent and parent.specials)}), symmeta = setmetatable({}, {__index = (parent and parent.symmeta)}), unmanglings = setmetatable({}, {__index = (parent and parent.unmanglings)}), vararg = (parent and parent.vararg)}
   end
   local function assert_msg(ast, msg)
     local ast_tbl = nil
@@ -2261,10 +2309,10 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   end
   local function assert_compile(condition, msg, ast, _3ffallback_ast)
     if not condition then
-      local _263_ = (utils.root.options or {})
-      local error_pinpoint = _263_["error-pinpoint"]
-      local source = _263_["source"]
-      local unfriendly = _263_["unfriendly"]
+      local _264_ = (utils.root.options or {})
+      local error_pinpoint = _264_["error-pinpoint"]
+      local source = _264_["source"]
+      local unfriendly = _264_["unfriendly"]
       local ast0 = nil
       if next(utils["ast-source"](ast)) then
         ast0 = ast
@@ -2288,33 +2336,33 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   scopes.macro = scopes.global
   local serialize_subst = {["\11"] = "\\v", ["\12"] = "\\f", ["\7"] = "\\a", ["\8"] = "\\b", ["\9"] = "\\t", ["\n"] = "n"}
   local function serialize_string(str)
-    local function _268_(_241)
+    local function _269_(_241)
       return ("\\" .. _241:byte())
     end
-    return string.gsub(string.gsub(string.format("%q", str), ".", serialize_subst), "[\128-\255]", _268_)
+    return string.gsub(string.gsub(string.format("%q", str), ".", serialize_subst), "[\128-\255]", _269_)
   end
   local function global_mangling(str)
     if utils["valid-lua-identifier?"](str) then
       return str
     else
-      local function _269_(_241)
+      local function _270_(_241)
         return string.format("_%02x", _241:byte())
       end
-      return ("__fnl_global__" .. str:gsub("[^%w]", _269_))
+      return ("__fnl_global__" .. str:gsub("[^%w]", _270_))
     end
   end
   local function global_unmangling(identifier)
-    local _271_0 = string.match(identifier, "^__fnl_global__(.*)$")
-    if (nil ~= _271_0) then
-      local rest = _271_0
-      local _272_0 = nil
-      local function _273_(_241)
+    local _272_0 = string.match(identifier, "^__fnl_global__(.*)$")
+    if (nil ~= _272_0) then
+      local rest = _272_0
+      local _273_0 = nil
+      local function _274_(_241)
         return string.char(tonumber(_241:sub(2), 16))
       end
-      _272_0 = string.gsub(rest, "_[%da-f][%da-f]", _273_)
-      return _272_0
+      _273_0 = string.gsub(rest, "_[%da-f][%da-f]", _274_)
+      return _273_0
     else
-      local _ = _271_0
+      local _ = _272_0
       return identifier
     end
   end
@@ -2338,10 +2386,10 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       raw = str
     end
     local mangling = nil
-    local function _277_(_241)
+    local function _278_(_241)
       return string.format("_%02x", _241:byte())
     end
-    mangling = string.gsub(string.gsub(raw, "-", "_"), "[^%w_]", _277_)
+    mangling = string.gsub(string.gsub(raw, "-", "_"), "[^%w_]", _278_)
     local unique = unique_mangling(mangling, mangling, scope, 0)
     scope.unmanglings[unique] = (scope["gensym-base"][str] or str)
     do
@@ -2396,29 +2444,29 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     return table.concat(parts, ".")
   end
   local function autogensym(base, scope)
-    local _281_0 = utils["multi-sym?"](base)
-    if (nil ~= _281_0) then
-      local parts = _281_0
+    local _282_0 = utils["multi-sym?"](base)
+    if (nil ~= _282_0) then
+      local parts = _282_0
       return combine_auto_gensym(parts, autogensym(parts[1], scope))
     else
-      local _ = _281_0
-      local function _282_()
+      local _ = _282_0
+      local function _283_()
         local mangling = gensym(scope, base:sub(1, ( - 2)), "auto")
         scope.autogensyms[base] = mangling
         return mangling
       end
-      return (scope.autogensyms[base] or _282_())
+      return (scope.autogensyms[base] or _283_())
     end
   end
   local function check_binding_valid(symbol, scope, ast, _3fopts)
     local name = tostring(symbol)
     local macro_3f = nil
     do
-      local _284_0 = _3fopts
-      if (nil ~= _284_0) then
-        _284_0 = _284_0["macro?"]
+      local _285_0 = _3fopts
+      if (nil ~= _285_0) then
+        _285_0 = _285_0["macro?"]
       end
-      macro_3f = _284_0
+      macro_3f = _285_0
     end
     assert_compile(not name:find("&"), "invalid character: &", symbol)
     assert_compile(not name:find("^%."), "invalid character: .", symbol)
@@ -2516,22 +2564,22 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   end
   local function flatten_chunk(file_sourcemap, chunk, tab, depth)
     if chunk.leaf then
-      local _296_ = utils["ast-source"](chunk.ast)
-      local filename = _296_["filename"]
-      local line = _296_["line"]
+      local _297_ = utils["ast-source"](chunk.ast)
+      local filename = _297_["filename"]
+      local line = _297_["line"]
       table.insert(file_sourcemap, {filename, line})
       return chunk.leaf
     else
       local tab0 = nil
       do
-        local _297_0 = tab
-        if (_297_0 == true) then
+        local _298_0 = tab
+        if (_298_0 == true) then
           tab0 = "  "
-        elseif (_297_0 == false) then
+        elseif (_298_0 == false) then
           tab0 = ""
-        elseif (_297_0 == tab) then
+        elseif (_298_0 == tab) then
           tab0 = tab
-        elseif (_297_0 == nil) then
+        elseif (_298_0 == nil) then
           tab0 = ""
         else
         tab0 = nil
@@ -2577,7 +2625,7 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     end
   end
   local function make_metadata()
-    local function _305_(self, tgt, _3fkey)
+    local function _306_(self, tgt, _3fkey)
       if self[tgt] then
         if (nil ~= _3fkey) then
           return self[tgt][_3fkey]
@@ -2586,12 +2634,12 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
         end
       end
     end
-    local function _308_(self, tgt, key, value)
+    local function _309_(self, tgt, key, value)
       self[tgt] = (self[tgt] or {})
       self[tgt][key] = value
       return tgt
     end
-    local function _309_(self, tgt, ...)
+    local function _310_(self, tgt, ...)
       local kv_len = select("#", ...)
       local kvs = {...}
       if ((kv_len % 2) ~= 0) then
@@ -2603,7 +2651,7 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       end
       return tgt
     end
-    return setmetatable({}, {__index = {get = _305_, set = _308_, setall = _309_}, __mode = "k"})
+    return setmetatable({}, {__index = {get = _306_, set = _309_, setall = _310_}, __mode = "k"})
   end
   local function exprs1(exprs)
     return table.concat(utils.map(exprs, tostring), ", ")
@@ -2649,14 +2697,14 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     end
     if opts.target then
       local result = exprs1(exprs)
-      local function _317_()
+      local function _318_()
         if (result == "") then
           return "nil"
         else
           return result
         end
       end
-      emit(parent, string.format("%s = %s", opts.target, _317_()), ast)
+      emit(parent, string.format("%s = %s", opts.target, _318_()), ast)
     end
     if (opts.tail or opts.target) then
       return {returned = true}
@@ -2668,16 +2716,16 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   local function find_macro(ast, scope)
     local macro_2a = nil
     do
-      local _320_0 = utils["sym?"](ast[1])
-      if (_320_0 ~= nil) then
-        local _321_0 = tostring(_320_0)
-        if (_321_0 ~= nil) then
-          macro_2a = scope.macros[_321_0]
+      local _321_0 = utils["sym?"](ast[1])
+      if (_321_0 ~= nil) then
+        local _322_0 = tostring(_321_0)
+        if (_322_0 ~= nil) then
+          macro_2a = scope.macros[_322_0]
         else
-          macro_2a = _321_0
+          macro_2a = _322_0
         end
       else
-        macro_2a = _320_0
+        macro_2a = _321_0
       end
     end
     local multi_sym_parts = utils["multi-sym?"](ast[1])
@@ -2689,12 +2737,12 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       return macro_2a
     end
   end
-  local function propagate_trace_info(_325_0, _index, node)
-    local _326_ = _325_0
-    local byteend = _326_["byteend"]
-    local bytestart = _326_["bytestart"]
-    local filename = _326_["filename"]
-    local line = _326_["line"]
+  local function propagate_trace_info(_326_0, _index, node)
+    local _327_ = _326_0
+    local byteend = _327_["byteend"]
+    local bytestart = _327_["bytestart"]
+    local filename = _327_["filename"]
+    local line = _327_["line"]
     do
       local src = utils["ast-source"](node)
       if (("table" == type(node)) and (filename ~= src.filename)) then
@@ -2707,8 +2755,8 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   local function quote_literal_nils(index, node, parent)
     if (parent and utils["list?"](parent)) then
       for i = 1, utils.maxn(parent) do
-        local _328_0 = parent[i]
-        if (_328_0 == nil) then
+        local _329_0 = parent[i]
+        if (_329_0 == nil) then
           parent[i] = utils.sym("nil")
         end
       end
@@ -2716,10 +2764,10 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     return index, node, parent
   end
   local function comp(f, g)
-    local function _331_(...)
+    local function _332_(...)
       return f(g(...))
     end
-    return _331_
+    return _332_
   end
   local function built_in_3f(m)
     local found_3f = false
@@ -2730,36 +2778,36 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     return found_3f
   end
   local function macroexpand_2a(ast, scope, _3fonce)
-    local _332_0 = nil
+    local _333_0 = nil
     if utils["list?"](ast) then
-      _332_0 = find_macro(ast, scope)
+      _333_0 = find_macro(ast, scope)
     else
-    _332_0 = nil
+    _333_0 = nil
     end
-    if (_332_0 == false) then
+    if (_333_0 == false) then
       return ast
-    elseif (nil ~= _332_0) then
-      local macro_2a = _332_0
+    elseif (nil ~= _333_0) then
+      local macro_2a = _333_0
       local old_scope = scopes.macro
       local _ = nil
       scopes.macro = scope
       _ = nil
       local ok, transformed = nil, nil
-      local function _334_()
+      local function _335_()
         return macro_2a(unpack(ast, 2))
       end
-      local function _335_()
+      local function _336_()
         if built_in_3f(macro_2a) then
           return tostring
         else
           return debug.traceback
         end
       end
-      ok, transformed = xpcall(_334_, _335_())
-      local function _336_(...)
+      ok, transformed = xpcall(_335_, _336_())
+      local function _337_(...)
         return propagate_trace_info(ast, ...)
       end
-      utils["walk-tree"](transformed, comp(_336_, quote_literal_nils))
+      utils["walk-tree"](transformed, comp(_337_, quote_literal_nils))
       scopes.macro = old_scope
       assert_compile(ok, transformed, ast)
       if (_3fonce or not transformed) then
@@ -2768,7 +2816,7 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
         return macroexpand_2a(transformed, scope)
       end
     else
-      local _ = _332_0
+      local _ = _333_0
       return ast
     end
   end
@@ -2800,13 +2848,13 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     assert_compile((utils["sym?"](ast[1]) or utils["list?"](ast[1]) or ("string" == type(ast[1]))), ("cannot call literal value " .. tostring(ast[1])), ast)
     for i = 2, len do
       local subexprs = nil
-      local _342_
+      local _343_
       if (i ~= len) then
-        _342_ = 1
+        _343_ = 1
       else
-      _342_ = nil
+      _343_ = nil
       end
-      subexprs = compile1(ast[i], scope, parent, {nval = _342_})
+      subexprs = compile1(ast[i], scope, parent, {nval = _343_})
       table.insert(fargs, subexprs[1])
       if (i == len) then
         for j = 2, #subexprs do
@@ -2844,13 +2892,13 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     end
   end
   local function compile_varg(ast, scope, parent, opts)
-    local _347_
+    local _348_
     if scope.hashfn then
-      _347_ = "use $... in hashfn"
+      _348_ = "use $... in hashfn"
     else
-      _347_ = "unexpected vararg"
+      _348_ = "unexpected vararg"
     end
-    assert_compile(scope.vararg, _347_, ast)
+    assert_compile(scope.vararg, _348_, ast)
     return handle_compile_opts({utils.expr("...", "varg")}, parent, opts, ast)
   end
   local function compile_sym(ast, scope, parent, opts)
@@ -2865,20 +2913,20 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     return handle_compile_opts({e}, parent, opts, ast)
   end
   local function serialize_number(n)
-    local _350_0 = string.gsub(tostring(n), ",", ".")
-    return _350_0
+    local _351_0 = string.gsub(tostring(n), ",", ".")
+    return _351_0
   end
   local function compile_scalar(ast, _scope, parent, opts)
     local serialize = nil
     do
-      local _351_0 = type(ast)
-      if (_351_0 == "nil") then
+      local _352_0 = type(ast)
+      if (_352_0 == "nil") then
         serialize = tostring
-      elseif (_351_0 == "boolean") then
+      elseif (_352_0 == "boolean") then
         serialize = tostring
-      elseif (_351_0 == "string") then
+      elseif (_352_0 == "string") then
         serialize = serialize_string
-      elseif (_351_0 == "number") then
+      elseif (_352_0 == "number") then
         serialize = serialize_number
       else
       serialize = nil
@@ -2891,8 +2939,8 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       if ((type(k) == "string") and utils["valid-lua-identifier?"](k)) then
         return k
       else
-        local _353_ = compile1(k, scope, parent, {nval = 1})
-        local compiled = _353_[1]
+        local _354_ = compile1(k, scope, parent, {nval = 1})
+        local compiled = _354_[1]
         return ("[" .. tostring(compiled) .. "]")
       end
     end
@@ -2918,12 +2966,12 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     do
       local tbl_17_ = buffer
       local i_18_ = #tbl_17_
-      for k, v in utils.stablepairs(ast) do
+      for k in utils.stablepairs(ast) do
         local val_19_ = nil
         if not keys[k] then
-          local _356_ = compile1(ast[k], scope, parent, {nval = 1})
-          local v0 = _356_[1]
-          val_19_ = string.format("%s = %s", escape_key(k), tostring(v0))
+          local _357_ = compile1(ast[k], scope, parent, {nval = 1})
+          local v = _357_[1]
+          val_19_ = string.format("%s = %s", escape_key(k), tostring(v))
         else
         val_19_ = nil
         end
@@ -2954,12 +3002,12 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
   end
   local function destructure(to, from, ast, scope, parent, opts)
     local opts0 = (opts or {})
-    local _360_ = opts0
-    local declaration = _360_["declaration"]
-    local forceglobal = _360_["forceglobal"]
-    local forceset = _360_["forceset"]
-    local isvar = _360_["isvar"]
-    local symtype = _360_["symtype"]
+    local _361_ = opts0
+    local declaration = _361_["declaration"]
+    local forceglobal = _361_["forceglobal"]
+    local forceset = _361_["forceset"]
+    local isvar = _361_["isvar"]
+    local symtype = _361_["symtype"]
     local symtype0 = ("_" .. (symtype or "dst"))
     local setter = nil
     if declaration then
@@ -2975,8 +3023,8 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
         return declare_local(symbol, nil, scope, symbol, new_manglings)
       else
         local parts = (utils["multi-sym?"](raw) or {raw})
-        local _362_ = parts
-        local first = _362_[1]
+        local _363_ = parts
+        local first = _363_[1]
         local meta = scope.symmeta[first]
         assert_compile(not raw:find(":"), "cannot set method sym", symbol)
         if ((#parts == 1) and not forceset) then
@@ -2997,14 +3045,14 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     end
     local function compile_top_target(lvalues)
       local inits = nil
-      local function _367_(_241)
+      local function _368_(_241)
         if scope.manglings[_241] then
           return _241
         else
           return "nil"
         end
       end
-      inits = utils.map(lvalues, _367_)
+      inits = utils.map(lvalues, _368_)
       local init = table.concat(inits, ", ")
       local lvalue = table.concat(lvalues, ", ")
       local plast = parent[#parent]
@@ -3042,7 +3090,7 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     local unpack_fn = "function (t, k, e)\n                        local mt = getmetatable(t)\n                        if 'table' == type(mt) and mt.__fennelrest then\n                          return mt.__fennelrest(t, k)\n                        elseif e then\n                          local rest = {}\n                          for k, v in pairs(t) do\n                            if not e[k] then rest[k] = v end\n                          end\n                          return rest\n                        else\n                          return {(table.unpack or unpack)(t, k)}\n                        end\n                      end"
     local function destructure_kv_rest(s, v, left, excluded_keys, destructure1)
       local exclude_str = nil
-      local _374_
+      local _375_
       do
         local tbl_17_ = {}
         local i_18_ = #tbl_17_
@@ -3053,9 +3101,9 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
             tbl_17_[i_18_] = val_19_
           end
         end
-        _374_ = tbl_17_
+        _375_ = tbl_17_
       end
-      exclude_str = table.concat(_374_, ", ")
+      exclude_str = table.concat(_375_, ", ")
       local subexpr = utils.expr(string.format(string.gsub(("(" .. unpack_fn .. ")(%s, %s, {%s})"), "\n%s*", " "), s, tostring(v), exclude_str), "expression")
       return destructure1(v, {subexpr}, left)
     end
@@ -3070,16 +3118,16 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       local s = gensym(scope, symtype0)
       local right = nil
       do
-        local _376_0 = nil
+        local _377_0 = nil
         if top_3f then
-          _376_0 = exprs1(compile1(from, scope, parent))
+          _377_0 = exprs1(compile1(from, scope, parent))
         else
-          _376_0 = exprs1(rightexprs)
+          _377_0 = exprs1(rightexprs)
         end
-        if (_376_0 == "") then
+        if (_377_0 == "") then
           right = "nil"
-        elseif (nil ~= _376_0) then
-          local right0 = _376_0
+        elseif (nil ~= _377_0) then
+          local right0 = _377_0
           right = right0
         else
         right = nil
@@ -3184,8 +3232,11 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     if opts.requireAsInclude then
       scope.specials.require = require_include
     end
-    local _390_ = utils.root
-    _390_["set-reset"](_390_)
+    if opts.assertAsRepl then
+      scope.macros.assert = scope.macros["assert-repl"]
+    end
+    local _392_ = utils.root
+    _392_["set-reset"](_392_)
     utils.root.chunk, utils.root.scope, utils.root.options = chunk, scope, opts
     for i = 1, #asts do
       local exprs = compile1(asts[i], scope, chunk, {nval = (((i < #asts) and 0) or nil), tail = (i == #asts)})
@@ -3236,14 +3287,14 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
         info.currentline = (remap[info.currentline][2] or -1)
       end
       if (info.what == "Lua") then
-        local function _395_()
+        local function _397_()
           if info.name then
             return ("'" .. info.name .. "'")
           else
             return "?"
           end
         end
-        return string.format("  %s:%d: in function %s", info.short_src, info.currentline, _395_())
+        return string.format("  %s:%d: in function %s", info.short_src, info.currentline, _397_())
       elseif (info.short_src == "(tail call)") then
         return "  (tail call)"
       else
@@ -3267,11 +3318,11 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       local done_3f, level = false, (_3fstart or 2)
       while not done_3f do
         do
-          local _399_0 = debug.getinfo(level, "Sln")
-          if (_399_0 == nil) then
+          local _401_0 = debug.getinfo(level, "Sln")
+          if (_401_0 == nil) then
             done_3f = true
-          elseif (nil ~= _399_0) then
-            local info = _399_0
+          elseif (nil ~= _401_0) then
+            local info = _401_0
             table.insert(lines, traceback_frame(info))
           end
         end
@@ -3281,14 +3332,14 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
     end
   end
   local function entry_transform(fk, fv)
-    local function _402_(k, v)
+    local function _404_(k, v)
       if (type(k) == "number") then
         return k, fv(v)
       else
         return fk(k), fv(v)
       end
     end
-    return _402_
+    return _404_
   end
   local function mixed_concat(t, joiner)
     local seen = {}
@@ -3333,10 +3384,10 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       return res[1]
     elseif utils["list?"](form) then
       local mapped = nil
-      local function _407_()
+      local function _409_()
         return nil
       end
-      mapped = utils.kvmap(form, entry_transform(_407_, q))
+      mapped = utils.kvmap(form, entry_transform(_409_, q))
       local filename = nil
       if form.filename then
         filename = string.format("%q", form.filename)
@@ -3354,13 +3405,13 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       else
         filename = "nil"
       end
-      local _410_
+      local _412_
       if source then
-        _410_ = source.line
+        _412_ = source.line
       else
-        _410_ = "nil"
+        _412_ = "nil"
       end
-      return string.format("setmetatable({%s}, {filename=%s, line=%s, sequence=%s})", mixed_concat(mapped, ", "), filename, _410_, "(getmetatable(sequence()))['sequence']")
+      return string.format("setmetatable({%s}, {filename=%s, line=%s, sequence=%s})", mixed_concat(mapped, ", "), filename, _412_, "(getmetatable(sequence()))['sequence']")
     elseif (type(form) == "table") then
       local mapped = utils.kvmap(form, entry_transform(q, q))
       local source = getmetatable(form)
@@ -3370,14 +3421,14 @@ package.preload["fennel.compiler"] = package.preload["fennel.compiler"] or funct
       else
         filename = "nil"
       end
-      local function _413_()
+      local function _415_()
         if source then
           return source.line
         else
           return "nil"
         end
       end
-      return string.format("setmetatable({%s}, {filename=%s, line=%s})", mixed_concat(mapped, ", "), filename, _413_())
+      return string.format("setmetatable({%s}, {filename=%s, line=%s})", mixed_concat(mapped, ", "), filename, _415_())
     elseif (type(form) == "string") then
       return serialize_string(form)
     else
@@ -3599,7 +3650,9 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
       else
         r = getbyte({["stack-size"] = #stack})
       end
-      byteindex = (byteindex + 1)
+      if r then
+        byteindex = (byteindex + 1)
+      end
       if (r and char_starter_3f(r)) then
         col = (col + 1)
       end
@@ -3609,14 +3662,14 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
       return r
     end
     local function whitespace_3f(b)
-      local function _216_()
-        local _215_0 = options.whitespace
-        if (nil ~= _215_0) then
-          _215_0 = _215_0[b]
+      local function _217_()
+        local _216_0 = options.whitespace
+        if (nil ~= _216_0) then
+          _216_0 = _216_0[b]
         end
-        return _215_0
+        return _216_0
       end
-      return ((b == 32) or ((9 <= b) and (b <= 13)) or _216_())
+      return ((b == 32) or ((9 <= b) and (b <= 13)) or _217_())
     end
     local function parse_error(msg, _3fcol_adjust)
       local col0 = (col + (_3fcol_adjust or -1))
@@ -3636,38 +3689,38 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
         return nil
       end
       local function dispatch(v)
-        local _220_0 = stack[#stack]
-        if (_220_0 == nil) then
+        local _221_0 = stack[#stack]
+        if (_221_0 == nil) then
           retval, done_3f, whitespace_since_dispatch = v, true, false
           return nil
-        elseif ((_G.type(_220_0) == "table") and (nil ~= _220_0.prefix)) then
-          local prefix = _220_0.prefix
+        elseif ((_G.type(_221_0) == "table") and (nil ~= _221_0.prefix)) then
+          local prefix = _221_0.prefix
           local source0 = nil
           do
-            local _221_0 = table.remove(stack)
-            set_source_fields(_221_0)
-            source0 = _221_0
+            local _222_0 = table.remove(stack)
+            set_source_fields(_222_0)
+            source0 = _222_0
           end
           local list = utils.list(utils.sym(prefix, source0), v)
           for k, v0 in pairs(source0) do
             list[k] = v0
           end
           return dispatch(list)
-        elseif (nil ~= _220_0) then
-          local top = _220_0
+        elseif (nil ~= _221_0) then
+          local top = _221_0
           whitespace_since_dispatch = false
           return table.insert(top, v)
         end
       end
       local function badend()
         local accum = utils.map(stack, "closer")
-        local _223_
+        local _224_
         if (#stack == 1) then
-          _223_ = ""
+          _224_ = ""
         else
-          _223_ = "s"
+          _224_ = "s"
         end
-        return parse_error(string.format("expected closing delimiter%s %s", _223_, string.char(unpack(accum))))
+        return parse_error(string.format("expected closing delimiter%s %s", _224_, string.char(unpack(accum))))
       end
       local function skip_whitespace(b)
         if (b and whitespace_3f(b)) then
@@ -3681,11 +3734,11 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
       end
       local function parse_comment(b, contents)
         if (b and (10 ~= b)) then
-          local function _226_()
+          local function _227_()
             table.insert(contents, string.char(b))
             return contents
           end
-          return parse_comment(getb(), _226_())
+          return parse_comment(getb(), _227_())
         elseif comments then
           ungetb(10)
           return dispatch(utils.comment(table.concat(contents), {filename = filename, line = line}))
@@ -3711,12 +3764,12 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
         return dispatch(setmetatable(tbl, mt))
       end
       local function add_comment_at(comments0, index, node)
-        local _230_0 = comments0[index]
-        if (nil ~= _230_0) then
-          local existing = _230_0
+        local _231_0 = comments0[index]
+        if (nil ~= _231_0) then
+          local existing = _231_0
           return table.insert(existing, node)
         else
-          local _ = _230_0
+          local _ = _231_0
           comments0[index] = {node}
           return nil
         end
@@ -3795,16 +3848,16 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
         end
         local state0 = nil
         do
-          local _241_0 = {state, b}
-          if ((_G.type(_241_0) == "table") and (_241_0[1] == "base") and (_241_0[2] == 92)) then
+          local _242_0 = {state, b}
+          if ((_G.type(_242_0) == "table") and (_242_0[1] == "base") and (_242_0[2] == 92)) then
             state0 = "backslash"
-          elseif ((_G.type(_241_0) == "table") and (_241_0[1] == "base") and (_241_0[2] == 34)) then
+          elseif ((_G.type(_242_0) == "table") and (_242_0[1] == "base") and (_242_0[2] == 34)) then
             state0 = "done"
-          elseif ((_G.type(_241_0) == "table") and (_241_0[1] == "backslash") and (_241_0[2] == 10)) then
+          elseif ((_G.type(_242_0) == "table") and (_242_0[1] == "backslash") and (_242_0[2] == 10)) then
             table.remove(chars, (#chars - 1))
             state0 = "base"
           else
-            local _ = _241_0
+            local _ = _242_0
             state0 = "base"
           end
         end
@@ -3826,11 +3879,11 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
         table.remove(stack)
         local raw = table.concat(chars)
         local formatted = raw:gsub("[\7-\13]", escape_char)
-        local _245_0 = (rawget(_G, "loadstring") or load)(("return " .. formatted))
-        if (nil ~= _245_0) then
-          local load_fn = _245_0
+        local _246_0 = (rawget(_G, "loadstring") or load)(("return " .. formatted))
+        if (nil ~= _246_0) then
+          local load_fn = _246_0
           return dispatch(load_fn())
-        elseif (_245_0 == nil) then
+        elseif (_246_0 == nil) then
           return parse_error(("Invalid string: " .. raw))
         end
       end
@@ -3863,13 +3916,13 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
           dispatch((tonumber(number_with_stripped_underscores) or parse_error(("could not read number \"" .. rawstr .. "\""))))
           return true
         else
-          local _251_0 = tonumber(number_with_stripped_underscores)
-          if (nil ~= _251_0) then
-            local x = _251_0
+          local _252_0 = tonumber(number_with_stripped_underscores)
+          if (nil ~= _252_0) then
+            local x = _252_0
             dispatch(x)
             return true
           else
-            local _ = _251_0
+            local _ = _252_0
             return false
           end
         end
@@ -3917,7 +3970,7 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
         elseif delims[b] then
           close_table(b)
         elseif (b == 34) then
-          parse_string(b)
+          parse_string()
         elseif prefixes[b] then
           parse_prefix(b)
         elseif (sym_char_3f(b) or (b == string.byte("~"))) then
@@ -3935,11 +3988,11 @@ package.preload["fennel.parser"] = package.preload["fennel.parser"] or function(
       end
       return parse_loop(skip_whitespace(getb()))
     end
-    local function _258_()
+    local function _259_()
       stack, line, byteindex, col, lastb = {}, 1, 0, 0, nil
       return nil
     end
-    return parse_stream, _258_
+    return parse_stream, _259_
   end
   local function parser(stream_or_string, _3ffilename, _3foptions)
     local filename = (_3ffilename or "unknown")
@@ -4572,7 +4625,7 @@ package.preload["fennel.view"] = package.preload["fennel.view"] or function(...)
 end
 package.preload["fennel.utils"] = package.preload["fennel.utils"] or function(...)
   local view = require("fennel.view")
-  local version = "1.3.1"
+  local version = "1.4.0"
   local function luajit_vm_3f()
     return ((nil ~= _G.jit) and (type(_G.jit) == "table") and (nil ~= _G.jit.on) and (nil ~= _G.jit.off) and (type(_G.jit.version_num) == "number"))
   end
@@ -5040,7 +5093,8 @@ package.preload["fennel.utils"] = package.preload["fennel.utils"] or function(..
     return symbol.quoted
   end
   local function idempotent_expr_3f(x)
-    return ((type(x) == "string") or (type(x) == "integer") or (type(x) == "number") or (sym_3f(x) and not multi_sym_3f(x)))
+    local t = type(x)
+    return ((t == "string") or (t == "integer") or (t == "number") or (t == "boolean") or (sym_3f(x) and not multi_sym_3f(x)))
   end
   local function ast_source(ast)
     if (table_3f(ast) or sequence_3f(ast)) then
@@ -5174,14 +5228,14 @@ local function eval(str, _3foptions, ...)
   local env = eval_env(opts.env, opts)
   local lua_source = compiler["compile-string"](str, opts)
   local loader = nil
-  local function _732_(...)
+  local function _745_(...)
     if opts.filename then
       return ("@" .. opts.filename)
     else
       return str
     end
   end
-  loader = specials["load-code"](lua_source, env, _732_(...))
+  loader = specials["load-code"](lua_source, env, _745_(...))
   opts.filename = nil
   return loader(...)
 end
@@ -5206,10 +5260,10 @@ local function syntax()
     out[k] = {["binding-form?"] = utils["member?"](k, binding_3f), ["body-form?"] = utils["member?"](k, body_3f), ["define?"] = utils["member?"](k, define_3f), ["macro?"] = true}
   end
   for k, v in pairs(_G) do
-    local _733_0 = type(v)
-    if (_733_0 == "function") then
+    local _746_0 = type(v)
+    if (_746_0 == "function") then
       out[k] = {["function?"] = true, ["global?"] = true}
-    elseif (_733_0 == "table") then
+    elseif (_746_0 == "table") then
       for k2, v2 in pairs(v) do
         if (("function" == type(v2)) and (k ~= "_G")) then
           out[(k .. "." .. k2)] = {["function?"] = true, ["global?"] = true}
@@ -5229,19 +5283,21 @@ utils["fennel-module"] = mod
 do
   local module_name = "fennel.macros"
   local _ = nil
-  local function _736_()
+  local function _749_()
     return mod
   end
-  package.preload[module_name] = _736_
+  package.preload[module_name] = _749_
   _ = nil
   local env = nil
   do
-    local _737_0 = specials["make-compiler-env"](nil, compiler.scopes.compiler, {})
-    _737_0["utils"] = utils
-    _737_0["fennel"] = mod
-    env = _737_0
+    local _750_0 = specials["make-compiler-env"](nil, compiler.scopes.compiler, {})
+    _750_0["utils"] = utils
+    _750_0["fennel"] = mod
+    env = _750_0
   end
-  local built_ins = eval([===[;; These macros are awkward because their definition cannot rely on the any
+  local built_ins = eval([===[;; fennel-ls: macro-file
+  
+  ;; These macros are awkward because their definition cannot rely on the any
   ;; built-in macros, only special forms. (no when, no icollect, etc)
   
   (fn copy [t]
@@ -5364,7 +5420,7 @@ do
               (table.remove iter-out i)))))
     (assert (or (not found?) (sym? into) (table? into) (list? into))
             "expected table, function call, or symbol in &into clause")
-    (values into iter-out))
+    (values into iter-out found?))
   
   (fn collect* [iter-tbl key-expr value-expr ...]
     "Return a table made by running an iterator and evaluating an expression that
@@ -5402,17 +5458,22 @@ do
     (assert (not= nil value-expr) "expected table value expression")
     (assert (= nil ...)
             "expected exactly one body expression. Wrap multiple expressions in do")
-    (let [(into iter) (extract-into iter-tbl)]
-      `(let [tbl# ,into]
-         ;; believe it or not, using a var here has a pretty good performance
-         ;; boost: https://p.hagelb.org/icollect-performance.html
-         (var i# (length tbl#))
-         (,how ,iter
-               (let [val# ,value-expr]
-                 (when (not= nil val#)
-                   (set i# (+ i# 1))
-                   (tset tbl# i# val#))))
-         tbl#)))
+    (let [(into iter has-into?) (extract-into iter-tbl)]
+      (if has-into?
+          `(let [tbl# ,into]
+             (,how ,iter (table.insert tbl# ,value-expr))
+             tbl#)
+          ;; believe it or not, using a var here has a pretty good performance
+          ;; boost: https://p.hagelb.org/icollect-performance.html
+          ;; but it doesn't always work with &into clauses, so skip if that's used
+          `(let [tbl# []]
+             (var i# 0)
+             (,how ,iter
+                   (let [val# ,value-expr]
+                     (when (not= nil val#)
+                       (set i# (+ i# 1))
+                       (tset tbl# i# val#))))
+             tbl#))))
   
   (fn icollect* [iter-tbl value-expr ...]
     "Return a sequential table made by running an iterator and evaluating an
@@ -5546,7 +5607,7 @@ do
             (.. "Expected n to be an integer >= 0, got " (tostring n)))
     (let [let-syms (list)
           let-values (if (= 1 (select "#" ...)) ... `(values ,...))]
-      (for [i 1 n]
+      (for [_ 1 n]
         (table.insert let-syms (gensym)))
       (if (= n 0) `(values)
           `(let [,let-syms ,let-values]
@@ -5631,6 +5692,30 @@ do
               (tset scope.macros import-key (. macros* macro-name))))))
     nil)
   
+  (fn assert-repl* [condition message ?opts]
+    "Drop into a debug repl and print the message when condition is false/nil.
+  Takes an optional table of arguments which will be passed to fennel.repl."
+    (fn add-locals [{: symmeta : parent} locals]
+      (each [name (pairs symmeta)]
+        (tset locals name (sym name)))
+      (if parent (add-locals parent locals) locals))
+    `(let [condition# ,condition
+           message# (or ,message "assertion failed, entering repl.")]
+       (if (not condition#)
+           (let [opts# (or ,?opts {:assert-repl? true
+                                   :readChunk (?. _G :___repl___ :readChunk)
+                                   :onError (?. _G :___repl___ :onError)
+                                   :onValued (?. _G :___repl___ :onValued)})
+                 fennel# (require (or opts#.moduleName :fennel))
+                 locals# ,(add-locals (get-scope) [])]
+             (set opts#.message (fennel#.traceback message#))
+             (set opts#.env (collect [k# v# (pairs _G) &into locals#]
+                              (if (= nil (. locals# k#)) (values k# v#))))
+             (_G.assert (fennel#.repl opts#) message#))
+           ;; `assert` returns *all* params on success, but omitting opts# to
+           ;; defensively prevent accidental leakage of REPL opts into code
+           (values condition# message#))))
+  
   {:-> ->*
    :->> ->>*
    :-?> -?>*
@@ -5651,14 +5736,17 @@ do
    :pick-values pick-values*
    :macro macro*
    :macrodebug macrodebug*
-   :import-macros import-macros*}
+   :import-macros import-macros*
+   :assert-repl assert-repl*}
   ]===], {env = env, filename = "src/fennel/macros.fnl", moduleName = module_name, scope = compiler.scopes.compiler, useMetadata = true})
   local _0 = nil
   for k, v in pairs(built_ins) do
     compiler.scopes.global.macros[k] = v
   end
   _0 = nil
-  local match_macros = eval([===[;;; Pattern matching
+  local match_macros = eval([===[;; fennel-ls: macro-file
+  
+  ;;; Pattern matching
   ;; This is separated out so we can use the "core" macros during the
   ;; implementation of pattern matching.
   
@@ -5761,7 +5849,7 @@ do
                      (let [in-pattern (symbols-in-pattern pattern)]
                        (if ?symbols
                          (do
-                           (each [name symbol (pairs ?symbols)]
+                           (each [name (pairs ?symbols)]
                              (when (not (. in-pattern name))
                                (tset ?symbols name nil)))
                            ?symbols)
@@ -5777,7 +5865,7 @@ do
       (if (= 0 (length bindings))
         ;; no bindings special case generates simple code
         (let [condition
-              (icollect [i subpattern (ipairs pattern) &into `(or)]
+              (icollect [_ subpattern (ipairs pattern) &into `(or)]
                 (let [(subcondition subbindings) (case-pattern vals subpattern unifications opts)]
                   subcondition))]
           (values
@@ -5790,7 +5878,7 @@ do
               bindings-mangled (icollect [_ binding (ipairs bindings)]
                                  (gensym (tostring binding)))
               pre-bindings `(if)]
-          (each [i subpattern (ipairs pattern)]
+          (each [_ subpattern (ipairs pattern)]
             (let [(subcondition subbindings) (case-guard vals subpattern guards {} case-pattern opts)]
               (table.insert pre-bindings subcondition)
               (table.insert pre-bindings `(let ,subbindings
@@ -5956,7 +6044,7 @@ do
         (case-condition (list val) clauses match?)
         ;; protect against multiple evaluation of the value, bind against as
         ;; many values as we ever match against in the clauses.
-        (let [vals (fcollect [i 1 vals-count &into (list)] (gensym))]
+        (let [vals (fcollect [_ 1 vals-count &into (list)] (gensym))]
           (list `let [vals val] (case-condition vals clauses match?))))))
   
   (fn case* [val ...]


### PR DESCRIPTION
```text
## 1.4.0 / 2023-12-01

### Bug Fixes
* Prevent metadata from being accessible in compiler sandbox.

### New Forms
* Add `tail!` which asserts that the argument is called in tail position.
* Add `assert-repl` to make an assertion which opens a repl when it fails.

### New Features
* Add `--assert-as-repl` flag to replace `assert` calls with `assert-repl`.
* Allow you to return a value from the repl with `,return FORM` command.
* Save previous REPL values in `*1`, `*2`, and `*3` locals.
* Make repl prompt change when repl sessions get nested.
```