### PR TITLE
Adding tools medatada

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       pry (~> 0.14.2)
       rainbow (~> 3.1, >= 3.1.1)
       rbnacl (~> 7.1, >= 7.1.1)
-      ruby-openai (~> 6.3)
+      ruby-openai (~> 6.3, >= 6.3.1)
       sweet-moon (~> 0.0.7)
 
 GEM
@@ -32,7 +32,7 @@ GEM
       multipart-post (~> 2)
     faraday-net_http (3.0.2)
     ffi (1.16.3)
-    json (2.7.0)
+    json (2.7.1)
     language_server-protocol (3.17.0.3)
     method_source (1.0.0)
     multipart-post (2.3.0)
@@ -50,7 +50,7 @@ GEM
     rainbow (3.1.1)
     rbnacl (7.1.1)
       ffi
-    regexp_parser (2.8.2)
+    regexp_parser (2.8.3)
     rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -86,7 +86,7 @@ GEM
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
-    ruby-openai (6.3.0)
+    ruby-openai (6.3.1)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ bot.eval('Hello', as: 'eval')
 bot.eval('Hello', as: 'repl')
 
 # When stream is enabled and available:
-bot.eval('Hi!') do |content, fragment, finished|
+bot.eval('Hi!') do |content, fragment, finished, meta|
   print fragment unless fragment.nil?
 end
 
@@ -235,7 +235,7 @@ bot.boot
 bot.boot(as: 'eval')
 bot.boot(as: 'repl')
 
-bot.boot do |content, fragment, finished|
+bot.boot do |content, fragment, finished, meta|
   print fragment unless fragment.nil?
 end
 ```

--- a/components/providers/openai.rb
+++ b/components/providers/openai.rb
@@ -49,7 +49,7 @@ module NanoBot
             end
           end
 
-          %i[instruction backdrop directive].each do |key|
+          %i[backdrop directive].each do |key|
             next unless input[:behavior][key]
 
             messages.prepend(

--- a/components/stream.rb
+++ b/components/stream.rb
@@ -13,9 +13,9 @@ module NanoBot
             @accumulated = "#{@accumulated.force_encoding('UTF-8')}#{args.first.force_encoding('UTF-8')}"
           end
 
-          @callback.call(@accumulated, args.first, false)
+          @callback.call(@accumulated, args.first, false, args[1])
         end
-        super
+        super(args.first)
       end
 
       def callback=(block)

--- a/controllers/interfaces/tools.rb
+++ b/controllers/interfaces/tools.rb
@@ -72,7 +72,10 @@ module NanoBot
 
           message = "#{adapter[:prefix]}#{message}#{adapter[:suffix]}"
 
-          session.print(color.nil? ? message : Rainbow(message).send(color))
+          session.print(
+            color.nil? ? message : Rainbow(message).send(color),
+            { tool: { action: feedback[:action].to_s } }
+          )
         end
 
         def self.adapter(cartridge, mode, feedback)

--- a/nano-bots.gemspec
+++ b/nano-bots.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'pry', '~> 0.14.2'
   spec.add_dependency 'rainbow', '~> 3.1', '>= 3.1.1'
   spec.add_dependency 'rbnacl', '~> 7.1', '>= 7.1.1'
-  spec.add_dependency 'ruby-openai', '~> 6.3'
+  spec.add_dependency 'ruby-openai', '~> 6.3', '>= 6.3.1'
   spec.add_dependency 'sweet-moon', '~> 0.0.7'
 
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/static/cartridges/default.yml
+++ b/static/cartridges/default.yml
@@ -9,8 +9,8 @@ interfaces:
   repl:
     output:
       stream: true
-      suffix: "\n"
       prefix: "\n"
+      suffix: "\n"
     prompt:
       - text: '🤖'
       - text: '> '


### PR DESCRIPTION
Adding metadata to tools in streaming callbacks:
```ruby
bot.eval('what time is it?') do |_, _, _, meta|
  puts meta.inspect
end
```

Fixed an issue that caused Nano Bots to enter an infinite loop when the REPL boot directive triggered a function call:
```yaml
---
behaviors:
  boot:
    directive: You are a helpful assistant.
    instruction: Provide a welcome message and share the current time with the user.
```

Upgrading to [ruby-openai](https://rubygems.org/gems/ruby-openai) 6.3.1