### PR TITLE
Remove version requirement for pry dependency

### DIFF
--- a/nano-bots.gemspec
+++ b/nano-bots.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'babosa', '~> 2.0'
   spec.add_dependency 'concurrent-ruby', '~> 1.3', '>= 1.3.3'
   spec.add_dependency 'dotenv', '~> 3.1', '>= 3.1.2'
-  spec.add_dependency 'pry', '~> 0.14.2'
+  spec.add_dependency 'pry'
   spec.add_dependency 'rainbow', '~> 3.1', '>= 3.1.1'
   spec.add_dependency 'rbnacl', '~> 7.1', '>= 7.1.1'
   spec.add_dependency 'redcarpet', '~> 3.6'


### PR DESCRIPTION
This change allows the library to be used within projects that don't use this specific version of pry.

I don't think it's meaningful in the current form since it's used for the REPL and can actually benefit from updates to the gem, while having a very low probability of breaking,